### PR TITLE
Add support for detecting IE8 and IE9 in compatability mode

### DIFF
--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -29,6 +29,8 @@ class Browser
   }
 
   VERSION_REGEX = /(?:Version|MSIE|Opera|Firefox|Chrome|QuickTime|BlackBerry[^\/]+|CoreMedia v)[\/ ]?([a-z0-9.]+)/i
+  
+  COMPATABILITY_VIEW_REGEXP = /Trident\/([0-9.]+)/
 
   LANGUAGES = {
     "af"    => "Afrikaans",
@@ -200,13 +202,23 @@ class Browser
 
   # Return the full version.
   def full_version
-    _, v = *ua.match(VERSION_REGEX)
+    if compatability_view?
+      _, v = *ua.match(COMPATABILITY_VIEW_REGEXP)
+      v.gsub!(/^([0-9])/) { $1.to_i + 4 }
+    else
+      _, v = *ua.match(VERSION_REGEX)
+    end
+    
     v || "0.0"
   end
 
   # Return true if browser supports some CSS 3 (Safari, Firefox, Opera & IE7+).
   def capable?
     webkit? || firefox? || opera? || (ie? && version >= "7")
+  end
+  
+  def compatability_view?
+    ie? && ua.match(COMPATABILITY_VIEW_REGEXP)
   end
 
   # Detect if browser is WebKit-based.

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -18,7 +18,9 @@ class BrowserTest < Test::Unit::TestCase
   IE6        = "Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 2.0.50727)"
   IE7        = "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)"
   IE8        = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.2; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)"
+  IE8_COMPAT = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/4.0; SLCC1; Media Center PC 5.0; .NET CLR 3.5.21022)"
   IE9        = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
+  IE9_COMPAT = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/5.0)"
   OPERA      = "Opera/9.99 (Windows NT 5.1; U; pl) Presto/9.9.9"
   FIREFOX    = "Mozilla/5.0 (X11; U; Linux i686; pl-PL; rv:1.9.0.2) Gecko/20121223 Ubuntu/9.25 (jaunty) Firefox/3.8"
   CHROME     = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.99 Safari/533.4"
@@ -148,6 +150,18 @@ class BrowserTest < Test::Unit::TestCase
     assert_equal "8.0", @browser.full_version
     assert_equal "8", @browser.version
   end
+  
+  def test_detect_ie8_in_compatibility_view
+    @browser.ua = IE8_COMPAT
+
+    assert_equal "Internet Explorer", @browser.name
+    assert @browser.ie?
+    assert @browser.ie8?
+    assert @browser.capable?
+    assert @browser.compatability_view?
+    assert_equal "8.0", @browser.full_version
+    assert_equal "8", @browser.version
+  end
 
   def test_detect_ie9
     @browser.ua = IE9
@@ -156,6 +170,18 @@ class BrowserTest < Test::Unit::TestCase
     assert @browser.ie?
     assert @browser.ie9?
     assert @browser.capable?
+    assert_equal "9.0", @browser.full_version
+    assert_equal "9", @browser.version
+  end
+  
+  def test_detect_ie9_in_compatibility_view
+    @browser.ua = IE9_COMPAT
+
+    assert_equal "Internet Explorer", @browser.name
+    assert @browser.ie?
+    assert @browser.ie9?
+    assert @browser.capable?
+    assert @browser.compatability_view?
     assert_equal "9.0", @browser.full_version
     assert_equal "9", @browser.version
   end


### PR DESCRIPTION
This pull request adds support for detecting IE8 and IE9 properly when running in compatibility mode. `ie8?` and `ie9?` now returns true, even when running in compatibility mode.

`compatability_mode?` is true if running IE8 or IE9 in compatibility mode.

See http://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx#TriToken for more information about the IE user agent strings.
