### PR TITLE
Improve handling of IE compatibility view

### DIFF
--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -30,7 +30,7 @@ class Browser
 
   VERSION_REGEX = /(?:Version|MSIE|Opera|Firefox|Chrome|QuickTime|BlackBerry[^\/]+|CoreMedia v)[\/ ]?([a-z0-9.]+)/i
 
-  COMPATIBILITY_VIEW_REGEXP = /Trident\/([0-9.]+)/
+  TRIDENT_VERSION_REGEX = /Trident\/([0-9.]+)/
 
   LANGUAGES = {
     "af"    => "Afrikaans",
@@ -202,13 +202,7 @@ class Browser
 
   # Return the full version.
   def full_version
-    if compatibility_view?
-      _, v = *ua.match(COMPATIBILITY_VIEW_REGEXP)
-      v.gsub!(/^([0-9])/) { $1.to_i + 4 }
-    else
-      _, v = *ua.match(VERSION_REGEX)
-    end
-
+    _, v = *ua.match(VERSION_REGEX)
     v || "0.0"
   end
 
@@ -218,7 +212,11 @@ class Browser
   end
 
   def compatibility_view?
-    ie? && ua.match(COMPATIBILITY_VIEW_REGEXP)
+    if ie? && ua.match(TRIDENT_VERSION_REGEX)
+      version.to_i < ($1.to_i + 4)
+    else
+      false
+    end
   end
 
   # Detect if browser is WebKit-based.

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -137,6 +137,7 @@ class BrowserTest < Test::Unit::TestCase
     assert @browser.ie?
     assert @browser.ie8?
     assert @browser.capable?
+    assert !@browser.compatibility_view?
     assert_equal "8.0", @browser.full_version
     assert_equal "8", @browser.version
   end
@@ -146,11 +147,12 @@ class BrowserTest < Test::Unit::TestCase
 
     assert_equal "Internet Explorer", @browser.name
     assert @browser.ie?
-    assert @browser.ie8?
+    assert @browser.ie7?
+    assert !@browser.ie8?
     assert @browser.capable?
     assert @browser.compatibility_view?
-    assert_equal "8.0", @browser.full_version
-    assert_equal "8", @browser.version
+    assert_equal "7.0", @browser.full_version
+    assert_equal "7", @browser.version
   end
 
   def test_detect_ie9
@@ -160,6 +162,7 @@ class BrowserTest < Test::Unit::TestCase
     assert @browser.ie?
     assert @browser.ie9?
     assert @browser.capable?
+    assert !@browser.compatibility_view?
     assert_equal "9.0", @browser.full_version
     assert_equal "9", @browser.version
   end
@@ -169,11 +172,12 @@ class BrowserTest < Test::Unit::TestCase
 
     assert_equal "Internet Explorer", @browser.name
     assert @browser.ie?
-    assert @browser.ie9?
+    assert @browser.ie7?
+    assert !@browser.ie9?
     assert @browser.capable?
     assert @browser.compatibility_view?
-    assert_equal "9.0", @browser.full_version
-    assert_equal "9", @browser.version
+    assert_equal "7.0", @browser.full_version
+    assert_equal "7", @browser.version
   end
 
   def test_detect_opera


### PR DESCRIPTION
This is related to issue #11. When in compatibility mode IE acts like an older version than is reported by the Trident version so we should use that as the version/full_version. Also correct bug that causes any version of IE to report that it's in compatibility mode.
