### PR TITLE
Fix up readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -40,7 +40,7 @@ Just add it to the Gemfile or `environment.rb`, depending of your Rails version.
 This adds a helper method called `browser`, that inspects your current user agent.
 
   <% if browser.ie6? %>
-    <p class="disclaimer">Your're running an older IE version. Please update it!</p>
+    <p class="disclaimer">You're running an older IE version. Please update it!</p>
   <% end %>
 
 == Maintainer


### PR DESCRIPTION
This commit adds an example showcasing the usage of `browser.name` in the usage section of the readme and fixes a typo.
