### PR TITLE
Support for older rails

### DIFF
--- a/lib/browser/action_controller.rb
+++ b/lib/browser/action_controller.rb
@@ -7,8 +7,8 @@ class Browser
     private
     def browser
       @browser ||= Browser.new(
-        :accept_language => request.headers["Accept-Language"],
-        :ua => request.headers["User-Agent"]
+        :accept_language => request.headers["Accept-Language"] || request.headers['HTTP_ACCEPT_LANGUAGE'],
+        :ua => request.headers["User-Agent"] || request.headers['HTTP_USER_AGENT']
       )
     end
   end


### PR DESCRIPTION
Hello,

I have a legacy (rails 2.0.2) app and needed to use your excellent gem. 
Trouble is, the headers have different names (I suspect, in pre-rack era).
