### PR TITLE
Use HTTPS for rubygems.org source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     browser (0.1.6)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionpack (3.2.11)
       activemodel (= 3.2.11)


### PR DESCRIPTION
The `:rubygems` source is deprecated by Bundler.
