### PR TITLE
Add PhantomJS

### DIFF
--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -27,11 +27,12 @@ class Browser
     :safari     => "Safari",
     :psp        => "PlayStation Portable",
     :quicktime  => "QuickTime",
-    :core_media => "Apple CoreMedia"
+    :core_media => "Apple CoreMedia",
+    :phantom_js => "PhantomJS"
   }
 
   VERSIONS = {
-    :default => /(?:Version|MSIE|Firefox|Chrome|CriOS|QuickTime|BlackBerry[^\/]+|CoreMedia v)[\/ ]?([a-z0-9.]+)/i,
+    :default => /(?:Version|MSIE|Firefox|Chrome|CriOS|QuickTime|BlackBerry[^\/]+|CoreMedia v|PhantomJS)[\/ ]?([a-z0-9.]+)/i,
     :opera => /Opera\/.*? Version\/([\d.]+)/
   }
 
@@ -190,6 +191,7 @@ class Browser
     when psp?         then :psp
     when quicktime?   then :quicktime
     when core_media?  then :core_media
+    when phantom_js?  then :phantom_js
     else
       :other
     end
@@ -255,6 +257,11 @@ class Browser
     !!(ua =~ /CoreMedia/)
   end
 
+  # Detect if browser is PhantomJS
+  def phantom_js?
+    !!(ua =~ /PhantomJS/)
+  end
+
   # Detect if browser is iPhone.
   def iphone?
     !!(ua =~ /iPhone/)
@@ -272,7 +279,7 @@ class Browser
 
   # Detect if browser is Safari.
   def safari?
-    ua =~ /Safari/ && ua !~ /Chrome|CriOS/
+    ua =~ /Safari/ && ua !~ /Chrome|CriOS|PhantomJS/
   end
 
   # Detect if browser is Firefox.

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -29,6 +29,7 @@ class BrowserTest < Test::Unit::TestCase
   WINDOWS_PHONE = "Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; DELL; Venue Pro)"
   KINDLE        = "Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600×800; rotate)"
   KINDLE_FIRE   = "Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Kindle Fire Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1"
+  PHANTOM_JS    = "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.0 Safari/534.34"
 
   def setup
     @browser = Browser.new
@@ -292,6 +293,18 @@ class BrowserTest < Test::Unit::TestCase
     assert_equal "Apple CoreMedia", @browser.name
     assert @browser.core_media?
     assert_equal "1.0.0.10F569", @browser.full_version
+    assert_equal "1", @browser.version
+  end
+
+  def test_detect_phantom_js
+    @browser.ua = PHANTOM_JS
+
+    assert_equal "PhantomJS", @browser.name
+    assert @browser.phantom_js?
+    assert @browser.tablet? == false
+    assert @browser.mobile? == false
+    assert @browser.capable?
+    assert_equal "1.9.0", @browser.full_version
     assert_equal "1", @browser.version
   end
 


### PR DESCRIPTION
PhantomJS is currently detected as Safari v0.0, which makes my integration tests kind of weird. I think this is better.
