### PR TITLE
Added support for bots detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ browser.mac?
 browser.windows?
 browser.linux?
 browser.blackberry?
+browser.bot?
 browser.meta        # an array with several attributes
 browser.to_s        # the meta info joined by space
 ```

--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -9,6 +9,7 @@ require "browser/methods/platform"
 require "browser/methods/mobile"
 require "browser/methods/devices"
 require "browser/methods/language"
+require "browser/methods/bots"
 
 require "browser/meta/base"
 require "browser/meta/generic_browser"
@@ -27,6 +28,7 @@ class Browser
   include Mobile
   include Devices
   include Language
+  include Bots
 
   # Set browser's UA string.
   attr_accessor :user_agent

--- a/lib/browser/methods/bots.rb
+++ b/lib/browser/methods/bots.rb
@@ -1,0 +1,76 @@
+class Browser
+  module Bots
+    # This initial list of bots was humbly borrowed from the split (https://github.com/andrew/split)
+    # gem.
+    BOTS = {
+      # Indexers
+      'AdsBot-Google' => 'Google Adwords',
+      'Baidu' => 'Chinese search engine',
+      'Baiduspider' => 'Chinese search engine',
+      'bingbot' => 'Microsoft bing bot',
+      'Butterfly' => 'Topsy Labs',
+      'Gigabot' => 'Gigabot spider',
+      'Googlebot' => 'Google spider',
+      'MJ12bot' => 'Majestic-12 spider',
+      'msnbot' => 'Microsoft bot',
+      'rogerbot' => 'SeoMoz spider',
+      'PaperLiBot' => 'PaperLi is another content curation service',
+      'Slurp' => 'Yahoo spider',
+      'Sogou' => 'Chinese search engine',
+      'spider' => 'generic web spider',
+      'UnwindFetchor' => 'Gnip crawler',
+      'WordPress' => 'WordPress spider',
+      'YandexBot' => 'Yandex spider',
+      'ZIBB' => 'ZIBB spider',
+
+      # HTTP libraries
+      'Apache-HttpClient' => 'Java http library',
+      'AppEngine-Google' => 'Google App Engine',
+      'curl' => 'curl unix CLI http client',
+      'ColdFusion' => 'ColdFusion http library',
+      'EventMachine HttpClient' => 'Ruby http library',
+      'Go http package' => 'Go http library',
+      'Java' => 'Generic Java http library',
+      'libwww-perl' => 'Perl client-server library loved by script kids',
+      'lwp-trivial' => 'Another Perl library loved by script kids',
+      'Python-urllib' => 'Python http library',
+      'PycURL' => 'Python http library',
+      'Test Certificate Info' => 'C http library?',
+      'Wget' => 'wget unix CLI http client',
+
+      # URL expanders / previewers
+      'awe.sm' => 'Awe.sm URL expander',
+      'bitlybot' => 'bit.ly bot',
+      'bot@linkfluence.net' => 'Linkfluence bot',
+      'facebookexternalhit' => 'facebook bot',
+      'Feedfetcher-Google' => 'Google Feedfetcher',
+      'https://developers.google.com/+/web/snippet' => 'Google+ Snippet Fetcher',
+      'LongURL' => 'URL expander service',
+      'NING' => 'NING - Yet Another Twitter Swarmer',
+      'redditbot' => 'Reddit Bot',
+      'ShortLinkTranslate' => 'Link shortener',
+      'TweetmemeBot' => 'TweetMeMe Crawler',
+      'Twitterbot' => 'Twitter URL expander',
+      'UnwindFetch' => 'Gnip URL expander',
+      'vkShare' => 'VKontake Sharer',
+
+      # Uptime monitoring
+      'check_http' => 'Nagios monitor',
+      'NewRelicPinger' => 'NewRelic monitor',
+      'Panopta' => 'Monitoring service',
+      'Pingdom' => 'Pingdom monitoring',
+      'SiteUptime' => 'Site monitoring services',
+
+      # ???
+      'DigitalPersona Fingerprint Software' => 'HP Fingerprint scanner',
+      'ShowyouBot' => 'Showyou iOS app spider',
+      'ZyBorg' => 'Zyborg? Hmmm....'
+    }.freeze
+
+    BOT_REGEX = /\b(?:#{BOTS.map { |key, _| Regexp.escape(key) }.join('|')})\b|\A\W*\z/i.freeze
+
+    def bot?
+      ua =~ BOT_REGEX
+    end
+  end
+end

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -45,6 +45,10 @@ class BrowserTest < Test::Unit::TestCase
   IOS5                  = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3"
   IOS6                  = "Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25"
   PLAYBOOK              = "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+"
+  CHROME                = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.99 Safari/533.4"
+  GOOGLE_BOT            = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+  MSN_BOT               = "msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)"
+  FACEBOOK_BOT          = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
 
   def setup
     @browser = Browser.new
@@ -669,5 +673,23 @@ class BrowserTest < Test::Unit::TestCase
   def test_meta_aliased_as_to_a
     @browser.ua = SAFARI
     assert_equal @browser.meta, @browser.to_a
+  end
+
+  def test_bots
+    @browser.ua = GOOGLE_BOT
+    assert @browser.bot?
+
+    @browser.ua = MSN_BOT
+    assert @browser.bot?
+
+    @browser.ua = FACEBOOK_BOT
+    assert @browser.bot?
+
+    # Many bots actually report empty ua strings.
+    @browser.ua = ''
+    assert @browser.bot?
+
+    @browser.ua = CHROME
+    assert ! @browser.bot?
   end
 end


### PR DESCRIPTION
The initial list of bots was humbly borrowed from the split (https://github.com/andrew/split) gem, which I've contributed to as well, and just intended to have this behavior inside the browser gem, where it should be.

Although the bots list if far from being complete,for all sakes and purposes, it's a very good start.
