### PR TITLE
Use HTTP 302 for redirect, as IE permanently caches HTTP 301

### DIFF
--- a/lib/browser/middleware.rb
+++ b/lib/browser/middleware.rb
@@ -33,7 +33,7 @@ class Browser
     end
 
     def redirect(path)
-      [301, {"Content-Type" => "text/html", "Location" => path}, []]
+      [302, {"Content-Type" => "text/html", "Location" => path}, []]
     end
 
     def run_app!

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -9,6 +9,11 @@ class MiddlewareTest < Test::Unit::TestCase
     Rails.application
   end
 
+  def test_redirect_uses_302
+    get "/", {}, {"HTTP_USER_AGENT" => "MSIE 6"}
+    assert_equal 302, last_response.status
+  end
+
   def test_redirect_ie6_to_upgrade_path
     get "/", {}, {"HTTP_USER_AGENT" => "MSIE 6"}
     follow_redirect!


### PR DESCRIPTION
The `redirect` feature of `Browser::Middleware` is intended for redirecting specific browser versions to an appropriate destination (e.g., a "browser not supported" page, or a reduced functionality app).

The current implementation sends a HTTP 301 redirect, which IE will permanently cache. This is problematic because if the redirect is changed or removed, any IE clients who have seen the redirect will not see the update.

This problem is compounded by the lack of IE11 support in the current release (all of our IE11 clients who were improperly directed to our "browser not supported" page will remember the redirect until the users manually clears their cache)
