### PR TITLE
Consider */* as a valid http_accept header for HTML

### DIFF
--- a/lib/browser/middleware.rb
+++ b/lib/browser/middleware.rb
@@ -50,8 +50,8 @@ class Browser
     end
 
     def html?(request)
-      ( request.env["HTTP_ACCEPT"].to_s.match( ACCEPT_REGEX ) and
-      not request.path.match(ASSETS_REGEX) )
+      (request.env["HTTP_ACCEPT"].to_s.match(ACCEPT_REGEX) &&
+      !request.path.match(ASSETS_REGEX))
     end
   end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -35,6 +35,13 @@ class MiddlewareTest < Test::Unit::TestCase
     assert_equal 404, last_response.status
   end
 
+  def test_redirect_ie8_with_wildcard_http_accept
+    get "/", {}, {"HTTP_USER_AGENT" => "MSIE 8", "HTTP_ACCEPT" => "*/*"}
+    follow_redirect!
+
+    assert_equal 404, last_response.status
+  end
+
   def test_ignores_non_html_requests
     get "/", {}, {"HTTP_USER_AGENT" => "MSIE 6", "HTTP_ACCEPT" => "image/png"}
 


### PR DESCRIPTION
Just two lines to allow IE 8 requests to be treat as HTML.

I think this is related to #72 and #79.
