### PR TITLE
revise modern? to exclude old, broken versions of webkit-based browsers

### DIFF
--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -85,7 +85,7 @@ class Browser
   end
 
   self.modern_rules.tap do |rules|
-    rules << -> b { b.webkit? }
+    rules << -> b { b.webkit? && b.webkit_version.to_i >= 532 }
     rules << -> b { b.firefox? && b.version.to_i >= 17 }
     rules << -> b { b.ie? && b.version.to_i >= 9 }
     rules << -> b { b.opera? && b.version.to_i >= 12 }
@@ -129,7 +129,15 @@ class Browser
     v.compact.first || "0.0"
   end
 
-  # Return true if browser is modern (Webkit, Firefox 17+, IE9+, Opera 12+).
+  # Return major webkit version.
+  def webkit_version
+    return nil if !webkit?
+
+    webkit_full_version = ua[%r|AppleWeb[Kk]it/([0-9.]+)|, 1]
+    webkit_full_version.to_s.split(".").first
+  end
+
+  # Return true if browser is modern (Webkit (Safari 4.1+, Chrome 3.0+), Firefox 17+, IE9+, Opera 12+).
   def modern?
     self.class.modern_rules.any? {|rule| rule === self }
   end

--- a/test/browser_spec.rb
+++ b/test/browser_spec.rb
@@ -45,8 +45,9 @@ describe Browser do
     assert @browser.iphone?
     assert @browser.safari?
     assert @browser.webkit?
+    assert_equal "420", @browser.webkit_version
     assert @browser.mobile?
-    assert @browser.modern?
+    assert ! @browser.modern?
     assert @browser.ios?
     assert ! @browser.tablet?
     assert_equal "3.0", @browser.full_version
@@ -59,9 +60,22 @@ describe Browser do
     assert_equal "Safari", @browser.name
     assert @browser.safari?
     assert @browser.webkit?
+    assert_equal "533", @browser.webkit_version
     assert @browser.modern?
     assert_equal "5.0.1", @browser.full_version
     assert_equal "5", @browser.version
+  end
+
+  it "detects non modern safari3 win" do
+    @browser.ua = $ua["SAFARI3_WIN"]
+
+    assert_equal "Safari", @browser.name
+    assert @browser.safari?
+    assert @browser.webkit?
+    assert_equal "525", @browser.webkit_version
+    assert !@browser.modern?
+    assert_equal "3.2.2", @browser.full_version
+    assert_equal "3", @browser.version
   end
 
   it "detects ipod" do
@@ -71,8 +85,9 @@ describe Browser do
     assert @browser.ipod?
     assert @browser.safari?
     assert @browser.webkit?
+    assert_equal "420", @browser.webkit_version
     assert @browser.mobile?
-    assert @browser.modern?
+    assert !@browser.modern?
     assert @browser.ios?
     assert ! @browser.tablet?
     assert_equal "3.0", @browser.full_version
@@ -86,7 +101,8 @@ describe Browser do
     assert @browser.ipad?
     assert @browser.safari?
     assert @browser.webkit?
-    assert @browser.modern?
+    assert_equal "531", @browser.webkit_version
+    assert ! @browser.modern?
     assert @browser.ios?
     assert @browser.tablet?
     assert ! @browser.mobile?
@@ -98,6 +114,8 @@ describe Browser do
     @browser.ua = $ua["IOS4"]
     assert @browser.ios?
     assert @browser.ios4?
+    assert @browser.webkit?
+    assert_equal "532", @browser.webkit_version
   end
 
 
@@ -105,12 +123,17 @@ describe Browser do
     @browser.ua = $ua["IOS5"]
     assert @browser.ios?
     assert @browser.ios5?
+
+    assert @browser.webkit?
+    assert_equal "534", @browser.webkit_version
   end
 
   it "detects ios6" do
     @browser.ua = $ua["IOS6"]
     assert @browser.ios?
     assert @browser.ios6?
+    assert @browser.webkit?
+    assert_equal "536", @browser.webkit_version
   end
 
   it "detects ios7" do
@@ -245,6 +268,7 @@ describe Browser do
     assert_equal :opera, @browser.id
     assert @browser.opera?
     assert @browser.webkit?
+    assert_equal "537", @browser.webkit_version
     assert @browser.modern?
     assert ! @browser.chrome?
     assert_equal "28.0.1500.37", @browser.full_version
@@ -290,6 +314,7 @@ describe Browser do
     assert @browser.chrome?
     assert ! @browser.safari?
     assert @browser.webkit?
+    assert_equal "533", @browser.webkit_version
     assert @browser.modern?
     assert_equal "5.0.375.99", @browser.full_version
     assert_equal "5", @browser.version
@@ -302,6 +327,7 @@ describe Browser do
     assert @browser.chrome?
     assert ! @browser.safari?
     assert @browser.webkit?
+    assert_equal "534", @browser.webkit_version
     assert @browser.modern?
     assert_equal "19.0.1084.60", @browser.full_version
     assert_equal "19", @browser.version
@@ -314,9 +340,10 @@ describe Browser do
     assert @browser.android?
     assert @browser.safari?
     assert @browser.webkit?
+    assert_equal "528", @browser.webkit_version
     assert @browser.mobile?
     assert ! @browser.tablet?
-    assert @browser.modern?
+    assert !@browser.modern?
     assert_equal "3.1.2", @browser.full_version
     assert_equal "3", @browser.version
   end
@@ -328,6 +355,7 @@ describe Browser do
     assert @browser.android?
     assert @browser.safari?
     assert @browser.webkit?
+    assert_equal "534", @browser.webkit_version
     assert ! @browser.mobile?
     assert @browser.tablet?
     assert @browser.modern?
@@ -445,6 +473,9 @@ describe Browser do
     assert @browser.phantom_js?
     assert ! @browser.tablet?
     assert ! @browser.mobile?
+    assert @browser.webkit?
+    assert_equal "534", @browser.webkit_version
+
     assert @browser.modern?
     assert_equal "1.9.0", @browser.full_version
     assert_equal "1", @browser.version
@@ -517,7 +548,7 @@ describe Browser do
     assert meta.include?("safari")
     assert meta.include?("safari3")
     assert meta.include?("mac")
-    assert meta.include?("modern")
+    assert !meta.include?("modern")
     assert meta.include?("mobile")
   end
 
@@ -622,6 +653,8 @@ describe Browser do
 
     assert @browser.android?
     assert @browser.tablet?
+    assert @browser.webkit?
+    assert_equal "534", @browser.webkit_version
     assert ! @browser.mobile?
   end
 
@@ -630,6 +663,10 @@ describe Browser do
 
     assert @browser.android?
     assert @browser.tablet?
+    assert @browser.webkit?
+    assert @browser.modern?
+
+    assert_equal "535", @browser.webkit_version
     assert ! @browser.mobile?
   end
 
@@ -639,6 +676,9 @@ describe Browser do
     assert ! @browser.android?
     assert @browser.tablet?
     assert ! @browser.mobile?
+
+    assert @browser.webkit?
+    assert_equal "536", @browser.webkit_version
 
     assert_equal "7.2.1.0", @browser.full_version
     assert_equal "7", @browser.version
@@ -718,6 +758,8 @@ describe Browser do
 
     assert @browser.kindle?
     assert @browser.webkit?
+    assert_equal "528", @browser.webkit_version
+
   end
 
   it "detects kindle fire" do
@@ -725,6 +767,7 @@ describe Browser do
 
     assert @browser.kindle?
     assert @browser.webkit?
+    assert_equal "533", @browser.webkit_version
   end
 
   it "detects kindle fire hd" do
@@ -733,6 +776,7 @@ describe Browser do
     assert @browser.silk?
     assert @browser.kindle?
     assert @browser.webkit?
+    assert_equal "535", @browser.webkit_version
     assert @browser.modern?
     assert ! @browser.mobile?
   end
@@ -743,6 +787,7 @@ describe Browser do
     assert @browser.silk?
     assert @browser.kindle?
     assert @browser.webkit?
+    assert_equal "535", @browser.webkit_version
     assert @browser.modern?
     assert @browser.mobile?
   end
@@ -751,6 +796,8 @@ describe Browser do
     @browser.ua = $ua["NOOK"]
 
     assert @browser.tablet?
+    assert @browser.webkit?
+    assert_equal "533", @browser.webkit_version
     assert ! @browser.mobile?
   end
 
@@ -758,6 +805,8 @@ describe Browser do
     @browser.ua = $ua["SAMSUNG"]
 
     assert @browser.tablet?
+    assert @browser.webkit?
+    assert_equal "534", @browser.webkit_version
     assert ! @browser.mobile?
   end
 

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -2,6 +2,7 @@ IPHONE: "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWe
 IPOD: "Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/3A100a Safari/419.3"
 IPAD: "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10"
 SAFARI: "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-us) AppleWebKit/533.17.8 (KHTML, like Gecko) Version/5.0.1 Safari/533.17.8"
+SAFARI3_WIN: "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/525.28 (KHTML, like Gecko) Version/3.2.2 Safari/525.28.1"
 IE6: "Mozilla/5.0 (Windows; U; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 2.0.50727)"
 IE7: "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 6.0; en-US)"
 IE8: "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.2; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)"


### PR DESCRIPTION
modern? no longer includes old, broken versions of Safari (mobile or desktop, less than v4.1) or Chrome (less than v3.x).

my previous pull request was closed, but it looks like the previous merge didn't quite succeed. rebased off of master as of right now, with tests added. tested with Safari 3.2 on Windows XP. 

PS: Technically, the existing IPHONE and IPAD entries in the UA list should be renamed to OLD_IPHONE and OLD_IPAD, as someone would have to somehow be using iOS 2.x for web browsing of modern sites but somehow still never have installed a firmware update.
