### PR TITLE
Introduce real_version helper

### DIFF
--- a/lib/browser/methods/ie.rb
+++ b/lib/browser/methods/ie.rb
@@ -40,12 +40,11 @@ class Browser
 
     # Detect if IE is running in compatibility mode.
     def compatibility_view?
-      match = ua.match(TRIDENT_VERSION_REGEX)
-      ie? && match && version.to_i < (match[1].to_i + 4)
+      ie? && version.to_i < real_version.to_i
     end
 
     def real_version
-      if ie? && compatibility_view? && match = ua.match(TRIDENT_VERSION_REGEX)
+      if ie? && match = ua.match(TRIDENT_VERSION_REGEX)
         (match[1].to_i + 4).to_s
       else
         version

--- a/lib/browser/methods/ie.rb
+++ b/lib/browser/methods/ie.rb
@@ -44,6 +44,14 @@ class Browser
       ie? && match && version.to_i < (match[1].to_i + 4)
     end
 
+    def real_version
+      if ie? && compatibility_view? && match = ua.match(TRIDENT_VERSION_REGEX)
+        (match[1].to_i + 4).to_s
+      else
+        version
+      end
+    end
+
     private
 
     def msie?

--- a/test/browser_spec.rb
+++ b/test/browser_spec.rb
@@ -235,6 +235,19 @@ describe Browser do
     assert_equal "11", @browser.real_version
   end
 
+  it "detects ie11 in compatibility view" do
+    @browser.ua = $ua["IE11_COMPAT"]
+
+    assert_equal "Internet Explorer", @browser.name
+    assert @browser.ie?
+    assert ! @browser.ie11?
+    assert ! @browser.modern?
+    assert @browser.compatibility_view?
+    assert_equal "7.0", @browser.full_version
+    assert_equal "7", @browser.version
+    assert_equal "11", @browser.real_version
+  end
+
   it "detects opera" do
     @browser.ua = $ua["OPERA"]
 

--- a/test/browser_spec.rb
+++ b/test/browser_spec.rb
@@ -151,6 +151,7 @@ describe Browser do
     assert ! @browser.compatibility_view?
     assert_equal "8.0", @browser.full_version
     assert_equal "8", @browser.version
+    assert_equal "8", @browser.real_version
   end
 
   it "detects ie8 in compatibility view" do
@@ -164,6 +165,7 @@ describe Browser do
     assert @browser.compatibility_view?
     assert_equal "7.0", @browser.full_version
     assert_equal "7", @browser.version
+    assert_equal "8", @browser.real_version
   end
 
   it "detects ie9" do
@@ -176,6 +178,7 @@ describe Browser do
     assert ! @browser.compatibility_view?
     assert_equal "9.0", @browser.full_version
     assert_equal "9", @browser.version
+    assert_equal "9", @browser.real_version
   end
 
   it "detects ie9 in compatibility view" do
@@ -189,6 +192,7 @@ describe Browser do
     assert @browser.compatibility_view?
     assert_equal "7.0", @browser.full_version
     assert_equal "7", @browser.version
+    assert_equal "9", @browser.real_version
   end
 
   it "detects ie10" do
@@ -201,6 +205,7 @@ describe Browser do
     assert ! @browser.compatibility_view?
     assert_equal "10.0", @browser.full_version
     assert_equal "10", @browser.version
+    assert_equal "10", @browser.real_version
   end
 
   it "detects ie10 in compatibility view" do
@@ -214,6 +219,7 @@ describe Browser do
     assert @browser.compatibility_view?
     assert_equal "7.0", @browser.full_version
     assert_equal "7", @browser.version
+    assert_equal "10", @browser.real_version
   end
 
   it "detects ie11" do
@@ -226,6 +232,7 @@ describe Browser do
     assert ! @browser.compatibility_view?
     assert_equal "11.0", @browser.full_version
     assert_equal "11", @browser.version
+    assert_equal "11", @browser.real_version
   end
 
   it "detects opera" do

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -12,6 +12,7 @@ IE10: "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; EIE10;EN
 IE10_COMPAT: "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; EIE10;ENUSMSN)"
 IE10_X64_WINX64: "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)"
 IE11: "Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko"
+IE11_COMPAT: "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C)"
 IE11_TOUCH_SCREEN: "Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; Touch; rv:11.0) like Gecko"
 OPERA: "Opera/9.80 (Macintosh; Intel Mac OS X 10.7.4; U; en) Presto/2.10.229 Version/11.64"
 OPERA_NEXT: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.37 Safari/537.36 OPR/15.0.1147.44 (Edition Next)"


### PR DESCRIPTION
hej,
small helping hand method to get the "not compatibility view"-Version of IE. 

This makes it easier to treat IE11 in compatibility view as modern browser

Example: 
```ruby
Browser.modern_rules << -> b { b.ie? && b.real_version.to_i >= 10 }
``` 