### PR TITLE
Browser outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The current rules that define a modern browser are pretty loose:
 * Firefox Tablet 14+
 * Opera 12+
 
-You can define your your rules. A rule must be a proc/lambda or any object that implements the method === and accepts the browser object. To redefine all rules, clear the existing rules before adding your own.
+You can define your own rules. A rule must be a proc/lambda or any object that implements the method === and accepts the browser object. To redefine all rules, clear the existing rules before adding your own.
 
 ```ruby
 # Only Chrome Canary is considered modern.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ browser.firefox?
 browser.ie?
 browser.ie6?            # this goes up to 11
 browser.modern?         # Webkit, Firefox 17+, IE 9+ and Opera 12+
+browser.outdated?       # Chrome < 27, Firefox < 17, IE < 10, Safari < 7, Opera < 13
 browser.platform        # return :mac, :windows, :linux or :other
 browser.mac?
 browser.windows?
@@ -68,6 +69,25 @@ Browser.modern_rules.clear
 Browser.modern_rules << -> b { b.chrome? && b.version >= '37' }
 ```
 
+### What defines a outdated browser?
+
+The current rules that define a outdated browser are:
+
+* Chrome < 27
+* Firefox < 17
+* IE < 10
+* Safari < 7
+* Opera? < 13
+* Firefox Android Tablet < 14
+
+You can define your own rules by appending proc/lambda or any object that implements the call method and accepts the browser object as parameter. To redefine all rules, clear the existing rules before adding your own.
+
+```ruby
+# Consider all IE as outdated.
+Browser.modern_rules << -> b { b.ie? }
+```
+
+
 ### Rails integration
 
 Just add it to the Gemfile.
@@ -99,6 +119,12 @@ You can use the `Browser::Middleware` to redirect user agents.
 ```ruby
 use Browser::Middleware do
   redirect_to "/upgrade" unless browser.modern?
+end
+```
+
+```ruby
+use Browser::Middleware do
+  redirect_to "/upgrade" if browser.outdated?
 end
 ```
 

--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -92,6 +92,29 @@ class Browser
     rules << -> b { b.firefox? && b.tablet? && b.android? && b.version.to_i >= 14 }
   end
 
+  # Define the rules which define a outdated browser.
+  # A rule must be a proc/lambda or any object that implements the method
+  # === and accepts the browser object.
+  #
+  # To redefine all rules, clear the existing rules before adding your own.
+  #
+  #   # Only Chrome Canary is considered outdated.
+  #   Browser.outdated_rules.clear
+  #   Browser.outdated_rules << -> b { b.chrome? && b.version < '27' }
+  #
+  def self.outdated_rules
+    @outdated_rules ||= []
+  end
+
+  self.outdated_rules.tap do |rules|
+    rules << -> b { b.chrome? && b.version.to_i < 27 }
+    rules << -> b { b.firefox? && b.version.to_i < 17 }
+    rules << -> b { b.ie? && b.version.to_i < 10 }
+    rules << -> b { b.safari? && b.version.to_i < 7 }
+    rules << -> b { b.opera? && b.version.to_i < 13 }
+    rules << -> b { b.firefox? && b.tablet? && b.android? && b.version.to_i < 14 }
+  end
+
   # Create a new browser instance and set
   # the UA and Accept-Language headers.
   #
@@ -132,6 +155,11 @@ class Browser
   # Return true if browser is modern (Webkit, Firefox 17+, IE9+, Opera 12+).
   def modern?
     self.class.modern_rules.any? {|rule| rule === self }
+  end
+
+  # Return true if browser is outdated
+  def outdated?
+    self.class.outdated_rules.any? { |rule| rule.call(browser) }
   end
 
   # Detect if browser is WebKit-based.

--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -106,7 +106,7 @@ class Browser
     @outdated_rules ||= []
   end
 
-  self.outdated_rules.tap do |rules|
+  outdated_rules.tap do |rules|
     rules << -> b { b.chrome? && b.version.to_i < 27 }
     rules << -> b { b.firefox? && b.version.to_i < 17 }
     rules << -> b { b.ie? && b.version.to_i < 10 }

--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -159,7 +159,7 @@ class Browser
 
   # Return true if browser is outdated
   def outdated?
-    self.class.outdated_rules.any? { |rule| rule.call(browser) }
+    self.class.outdated_rules.any? {|rule| rule.call(browser) }
   end
 
   # Detect if browser is WebKit-based.

--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -159,7 +159,7 @@ class Browser
 
   # Return true if browser is outdated
   def outdated?
-    self.class.outdated_rules.any? {|rule| rule.call(browser) }
+    self.class.outdated_rules.any? {|rule| rule.call(self) }
   end
 
   # Detect if browser is WebKit-based.

--- a/test/browser_spec.rb
+++ b/test/browser_spec.rb
@@ -126,6 +126,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie6?
     assert ! @browser.modern?
+    assert @browser.outdated?
     assert_equal "6.0", @browser.full_version
     assert_equal "6", @browser.version
   end
@@ -137,6 +138,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie7?
     assert ! @browser.modern?
+    assert @browser.outdated?
     assert_equal "7.0", @browser.full_version
     assert_equal "7", @browser.version
   end
@@ -148,6 +150,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie8?
     assert ! @browser.modern?
+    assert @browser.outdated?
     assert ! @browser.compatibility_view?
     assert_equal "8.0", @browser.full_version
     assert_equal "8", @browser.version
@@ -160,6 +163,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie7?
     assert ! @browser.ie8?
+    assert @browser.outdated?
     assert ! @browser.modern?
     assert @browser.compatibility_view?
     assert_equal "7.0", @browser.full_version
@@ -173,6 +177,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie9?
     assert @browser.modern?
+    assert @browser.outdated?
     assert ! @browser.compatibility_view?
     assert_equal "9.0", @browser.full_version
     assert_equal "9", @browser.version
@@ -186,6 +191,7 @@ describe Browser do
     assert @browser.ie7?
     assert ! @browser.ie9?
     assert ! @browser.modern?
+    assert @browser.outdated?
     assert @browser.compatibility_view?
     assert_equal "7.0", @browser.full_version
     assert_equal "7", @browser.version
@@ -198,6 +204,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie10?
     assert @browser.modern?
+    assert !@browser.outdated?
     assert ! @browser.compatibility_view?
     assert_equal "10.0", @browser.full_version
     assert_equal "10", @browser.version
@@ -211,6 +218,7 @@ describe Browser do
     assert @browser.ie7?
     assert ! @browser.ie10?
     assert ! @browser.modern?
+    assert @browser.outdated?
     assert @browser.compatibility_view?
     assert_equal "7.0", @browser.full_version
     assert_equal "7", @browser.version
@@ -223,6 +231,7 @@ describe Browser do
     assert @browser.ie?
     assert @browser.ie11?
     assert @browser.modern?
+    assert ! @browser.outdated?
     assert ! @browser.compatibility_view?
     assert_equal "11.0", @browser.full_version
     assert_equal "11", @browser.version


### PR DESCRIPTION
This pull request allows you to detect outdated browsers via pre-/self-defined rules. A rule must be a proc/lambda or any object that implements the call method and accepts the browser object as parameter. To redefine all rules, clear the existing rules before adding your own.

Define all IE as outdated:

``` ruby
# Consider all IE as outdated.
Browser.outdated_rules << -> b { b.ie? }
```

and redirect all outdated browser to the upgrade page. 

``` ruby
use Browser::Middleware do
  redirect_to "/upgrade" if browser.outdated?
end
```
