### PR TITLE
Don't confuse iOS devices for Macs

### DIFF
--- a/lib/browser/methods/platform.rb
+++ b/lib/browser/methods/platform.rb
@@ -57,7 +57,7 @@ class Browser
 
     # Detect if current platform is Macintosh.
     def mac?
-      !!(ua =~ /Mac OS X/) && ! ios?
+      !!(ua =~ /Mac OS X/) && !ios?
     end
 
     # Detect if current platform is Windows.


### PR DESCRIPTION
iOS devices have "..like Mac OS X.." in their user-agent strings but shouldn't return TRUE for .mac?
