### PR TITLE
Mention middleware request accessor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Rails.configuration.middleware.use Browser::Middleware do
 end
 ```
 
+If you need acccess to the `Rack::Request` object (e.g. to exclude a path), you can do so with `request`.
+```ruby
+Rails.configuration.middleware.use Browser::Middleware do
+  redirect_to upgrade_path unless browser.modern? || request.env['PATH_INFO'] == '/exclude_me'
+end
+```
+
 ## Maintainer
 
 * Nando Vieira - http://nandovieira.com.br


### PR DESCRIPTION
I had to go to [context.rb](https://github.com/fnando/browser/blob/master/lib/browser/middleware/context.rb) to find this, so perhaps it's worth mentioning in the README?