### PR TITLE
Add license to gemspec

### DIFF
--- a/browser.gemspec
+++ b/browser.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/fnando/browser"
   s.summary     = "Do some browser detection with Ruby."
   s.description = s.summary
+  s.license     = 'MIT'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.