### PR TITLE
Detect NT 5.2 as Windows XP

### DIFF
--- a/lib/browser/methods/platform.rb
+++ b/lib/browser/methods/platform.rb
@@ -72,7 +72,7 @@ class Browser
 
     ## More info here => http://msdn.microsoft.com/fr-FR/library/ms537503.aspx#PltToken
     def windows_xp?
-      windows? && !!(ua =~ /Windows NT 5.1/)
+      windows? && !!(ua =~ /Windows NT 5.[1-2]/)
     end
 
     def windows_vista?


### PR DESCRIPTION
Glad to see the windows version detecting functions merged in :smile: That will replace some regex matching that we are doing in our own code.

Our code matches NT 5.1 and 5.2 as Windows XP. It's listed in the microsoft documentation in the comment by the `windows_xp?` method. http://msdn.microsoft.com/fr-FR/library/ms537503.aspx#PltToken

Thanks for this gem, it's saving us a lot of regex effort.