### PR TITLE
Add desktop? method

### DIFF
--- a/lib/browser/methods/devices.rb
+++ b/lib/browser/methods/devices.rb
@@ -37,5 +37,9 @@ class Browser
     def windows_touchscreen_desktop?
       windows? && !!(ua =~ /Touch/)
     end
+    
+    def desktop?
+      !mobile? && !tablet?
+    end
   end
 end

--- a/test/browser_spec.rb
+++ b/test/browser_spec.rb
@@ -1027,4 +1027,13 @@ describe Browser do
     assert_equal @browser.full_version, "13.0"
     assert_equal @browser.name, "Other"
   end
+  
+  it "detects desktop" do
+    @browser.ua = $ua["CHROME"]
+
+    assert @browser.desktop?
+
+    @browser.ua = $ua["FIREFOX"]
+    assert @browser.desktop?
+  end
 end


### PR DESCRIPTION
I needed a method to check if the browser was a desktop, I could do this locally but thought it would be nice to have this as part of the gem.  This is the same as suggested within #136.