### PR TITLE
Detect iOS apps webview. Close #179.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ browser.name            # readable browser name
 browser.version         # major version number
 browser.full_version
 browser.safari?
+browser.ios?
+browser.app?      # request performed by ios' app webview 
 browser.opera?
 browser.chrome?
 browser.chrome_os?

--- a/browser.gemspec
+++ b/browser.gemspec
@@ -26,6 +26,9 @@ Gem::Specification.new do |s|
     "#   If this is important for you, please read             #"     ,
     "#   https://github.com/fnando/browser#internet-explorer   #"     ,
     "#                                                         #"     ,
+    "#   iOS webviews and web apps aren't detect as Safari     #"     ,
+    "#   anymore, so be aware of that if that's your case.     #"     ,
+    "#                                                         #"     ,
     "###########################################################"     ,
     "\n"
   ].join("\n")
@@ -37,4 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-utils"
   s.add_development_dependency "pry-meta"
+  s.add_development_dependency "minitest-autotest"
 end

--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -176,11 +176,11 @@ class Browser
 
   # Detect if browser is Safari.
   def safari?
-    (ua =~ /Safari/ || safari_webapp_mode?) && ua !~ /Android|Chrome|CriOS|PhantomJS/
+    !!((ua =~ /Safari/) && ua !~ /Android|Chrome|CriOS|PhantomJS/)
   end
 
   def safari_webapp_mode?
-    (ipad? || iphone?) && ua =~ /AppleWebKit/
+    !!((ipad? || iphone?) && ua =~ /AppleWebKit/)
   end
 
   # Detect if browser is Firefox.

--- a/lib/browser/methods/platform.rb
+++ b/lib/browser/methods/platform.rb
@@ -15,6 +15,16 @@ class Browser
       ua[/OS (\d)/, 1]
     end
 
+    # Detect if running on iOS app webview.
+    def ios_app?
+      ios? && !ua.include?("Safari")
+    end
+
+    # Detect if is iOS webview.
+    def ios_webview?
+      ios_app?
+    end
+
     # Detect if browser is ios?.
     def ios?(version = nil)
       (ipod? || ipad? || iphone?) && detect_version?(ios_version, version)

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -60,6 +60,7 @@ IOS6: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 
 IOS7: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53'
 IOS8: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A365 Safari/600.1.4'
 IOS9: 'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4'
+IOS_WEBVIEW: Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H141
 IPAD: 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10'
 IPHONE: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/1A542a Safari/419.3'
 IPOD: 'Mozilla/5.0 (iPod; U; CPU like Mac OS X; en) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/3A100a Safari/419.3'

--- a/test/unit/ios_app_test.rb
+++ b/test/unit/ios_app_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class IosAppTest < Minitest::Test
+  let(:browser) { Browser.new(ua: $ua["IOS_WEBVIEW"]) }
+
+  test "detect as ios" do
+    assert browser.ios?
+  end
+
+  test "don't detect as safari" do
+    refute browser.safari?
+  end
+
+  test "detect as webview" do
+    assert browser.ios_webview?
+  end
+end

--- a/test/unit/ios_test.rb
+++ b/test/unit/ios_test.rb
@@ -34,10 +34,12 @@ class IosTest < Minitest::Test
 
   test "detects safari in webapp mode" do
     @browser.ua = $ua["SAFARI_IPAD_WEBAPP_MODE"]
-    assert @browser.safari?
+    refute @browser.safari?
+    assert @browser.ios_webview?
 
     @browser.ua = $ua["SAFARI_IPHONE_WEBAPP_MODE"]
-    assert @browser.safari?
+    refute @browser.safari?
+    assert @browser.ios_webview?
   end
 
   test "detects ipod" do


### PR DESCRIPTION
The user agent from an app webview doesn't include the `Safari/:version` part. We can possibly detect if request is coming from an app's webview if it doesn't include this string.

Here's the user agent from Safari: 

```
Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H141 Safari/600.1.4
```

And here's the user agent from iOS webview:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H141
```