### PR TITLE
Add MS Edge to list of "modern" browsers in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The current rules that define a modern browser are pretty loose:
 
 * Webkit
 * IE9+
+* Microsoft Edge
 * Firefox 17+
 * Firefox Tablet 14+
 * Opera 12+


### PR DESCRIPTION
As of 6437455a6, Microsoft Edge is considered a "modern" browser by this gem.