### PR TITLE
method chrome? always return boolean value

### DIFF
--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -185,7 +185,7 @@ class Browser
 
   # Detect if browser is Chrome.
   def chrome?
-    ua =~ /Chrome|CriOS/ && !opera? && !edge?
+    !!(ua =~ /Chrome|CriOS/ && !opera? && !edge?)
   end
 
   # Detect if browser is Opera.

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -72,7 +72,7 @@ class BrowserTest < Minitest::Test
     @browser.ua = 'AnyOtherBrowser'
     refute @browser.chrome?
     refute_nil @browser.chrome?
-  end    
+  end
 
   test "detects surface tablet" do
     @browser.ua = $ua["SURFACE"]

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -69,7 +69,7 @@ class BrowserTest < Minitest::Test
     @browser.ua = $ua["CHROME"]
     assert @browser.chrome?
 
-    @browser.ua = 'AnyOtherBrowser'
+    @browser.ua = "AnyOtherBrowser"
     refute @browser.chrome?
     refute_nil @browser.chrome?
   end

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -65,6 +65,15 @@ class BrowserTest < Minitest::Test
     assert_equal "4", @browser.version
   end
 
+  test "detects chrome browser" do
+    @browser.ua = $ua["CHROME"]
+    assert @browser.chrome?
+
+    @browser.ua = 'AnyOtherBrowser'
+    refute @browser.chrome?
+    refute_nil @browser.chrome?
+  end    
+
   test "detects surface tablet" do
     @browser.ua = $ua["SURFACE"]
 


### PR DESCRIPTION
According to rails convention methods ending with '?' should always return boolean value

Rails console example:
2.1.1 :001 > browser = Browser.new({:ua => "Safari"})
=> # 
2.1.1 :004 > browser.safari?
=> true 
2.1.1 :003 > browser.firefox?
=> false 
2.1.1 :002 > browser.chrome?
=> nil

In ruby 'if false' and 'if nil' give the same result but for example when you need to generate server side javascript and you do 'if(browser.chrome?)' and it returns nil, javascript fails