### PR TITLE
Prevent error with empty ua string in bot detection

### DIFF
--- a/lib/browser/bot.rb
+++ b/lib/browser/bot.rb
@@ -58,7 +58,7 @@ module Browser
     end
 
     def downcased_ua
-      @downcased_ua ||= ua.downcase
+      @downcased_ua ||= ua && ua.downcase || ""
     end
   end
 end


### PR DESCRIPTION
Now that `detect_empty_ua!` is optional, a blank ua value is causing a NoMethodError when calling `downcase` in the `bot?` method.