### PR TITLE
add App to identify MicroMessenger(weixin) client

### DIFF
--- a/lib/browser.rb
+++ b/lib/browser.rb
@@ -6,6 +6,7 @@ require "browser/middleware"
 require "browser/middleware/context"
 require "browser/rails" if defined?(::Rails)
 
+require "browser/methods/app"
 require "browser/methods/ie"
 require "browser/methods/blackberry"
 require "browser/methods/platform"
@@ -28,6 +29,7 @@ require "browser/meta/safari"
 require "browser/meta/webkit"
 
 class Browser
+  include App
   include IE
   include BlackBerry
   include Platform
@@ -226,7 +228,10 @@ class Browser
 
   def detect_version?(actual_version, expected_version)
     return true unless expected_version
-    actual_version.to_s.start_with?(expected_version.to_s)
+    # actual_version.to_s.start_with?(expected_version.to_s)
+    # Use advanced version comparison
+    # detect_version?('1.2.5', '~> 1.2.3') => true
+    Gem::Requirement.create(expected_version).satisfied_by?(Gem::Version.create(actual_version))
   end
 
   def deprecate(message)

--- a/lib/browser/methods/app.rb
+++ b/lib/browser/methods/app.rb
@@ -1,0 +1,17 @@
+class Browser
+  module App
+
+    # Weixin App
+    def weixin?(version = nil)
+      !!(ua =~ /MicroMessenger/) && detect_version?(weixin_version, version)
+    end
+
+    def weixin_version
+      ua[/MicroMessenger\/([\d.]+)/, 1]
+    end
+
+    alias_method :wechat?, :weixin?
+    alias_method :wechat_version, :weixin_version
+
+  end
+end


### PR DESCRIPTION
Hi, I'm making this can identify app browsers such as [Wechat App](http://www.wechat.com):

UserAgent: `Mozilla/5.0 (iPhone; CPU iPhone OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H321 MicroMessenger/6.3.9 wxdebugger/0.3.0 Language/zh_CN webviewId/0`

`browser.weixin?`