### PR TITLE
Get device name from android devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Detect Edge based on Chrome correctly.
 - Improve Yandex detection.
 - Add Sputnik (https://browser.sputnik.ru)
+- Detect Android devices.
 
 ## 2.6.1
 

--- a/lib/browser/device.rb
+++ b/lib/browser/device.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "browser/device/base"
+require "browser/device/android"
 require "browser/device/unknown"
 require "browser/device/ipad"
 require "browser/device/ipod_touch"
@@ -45,6 +46,7 @@ module Browser
         Ipad,
         Iphone,
         IpodTouch,
+        Android,
         Unknown
       ]
     end

--- a/lib/browser/device/android.rb
+++ b/lib/browser/device/android.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Browser
+  class Device
+    class Android < Base
+      def id
+        :unknown
+      end
+
+      def name
+        ua[/\(Linux.*?; Android.*?; ([-_a-z0-9 ]+) Build[^)]+\)/i, 1] ||
+          "Unknown"
+      end
+
+      def match?
+        ua =~ /Android/
+      end
+    end
+  end
+end

--- a/lib/browser/device/tv.rb
+++ b/lib/browser/device/tv.rb
@@ -12,7 +12,7 @@ module Browser
       end
 
       def match?
-        ua =~ /(tv|Android.*?ADT-1|Nexus Player)/i
+        ua =~ /(\btv|Android.*?ADT-1|Nexus Player)/i
       end
     end
   end

--- a/test/unit/device_test.rb
+++ b/test/unit/device_test.rb
@@ -238,4 +238,24 @@ class DeviceTest < Minitest::Test
       refute device.mobile?
     end
   end
+
+  {
+    "ANDROID_CUPCAKE" => "T-Mobile G1",
+    "ANDROID_DONUT" => "SonyEricssonX10i",
+    "ANDROID_ECLAIR_21" => "Nexus One",
+    "ANDROID_FROYO" => "HTC_DesireHD_A9191",
+    "ANDROID_GINGERBREAD" => "Sensation_4G",
+    "ANDROID_HONEYCOMB_30" => "Xoom",
+    "ANDROID_ICECREAM" => "sdk",
+    "ANDROID_JELLYBEAN_41" => "Nexus S",
+    "ANDROID_JELLYBEAN_42" => "Nexus 10",
+    "ANDROID_JELLYBEAN_43" => "Nexus 7",
+    "CUSTOM_APP" => "HTC Ruby",
+    "NOOK" => "NOOK BNTV250A"
+  }.each do |key, name|
+    test "detect device name of #{key} as #{name}" do
+      device = Browser::Device.new(Browser[key])
+      assert_equal name, device.name
+    end
+  end
 end


### PR DESCRIPTION
Close #231.

The biggest issue here is which id should be returned. We can't dynamically generate it because we need a reliable value.
