### PR TITLE
Fix Travis tests for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- '2.3.1'
-- '2.2'
-- '2.1'
+  - '2.3.1'
+  - '2.2.2'
+  - '2.1'
 gemfile:
-- Gemfile
-- gemfiles/rails3.gemfile
+  - Gemfile
+  - gemfiles/rails3.gemfile
+  - gemfiles/rails4.gemfile
+matrix:
+ exclude:
+   - rvm: '2.1'
+     gemfile: Gemfile
 script: bundle exec rake
 notifications:
   email: false

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec path: ".."
+
+gem "rails", '~> 4.0'


### PR DESCRIPTION
Add gemfile for Rails 4, bump 2.2 to 2.2.2, prevent Rails 5 test on 2.1.