### PR TITLE
[BUGFIX] ensures that iOS platform detection uses full version and not only major version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 doc
 log
 *.lock
+bin/*

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -3,10 +3,21 @@ module Browser
   class Platform
     class IOS < Base
       MATCHER = /(iPhone|iPad|iPod)/
-      VERSION_MATCHER = /OS ([\d.]+)/
+      VERSION_MATCHER = /OS ((?<major>\d)_(?<minor>\d)_?(?<patch>\d)?)/
 
       def version
-        ua[VERSION_MATCHER, 1] || "0"
+        matches = VERSION_MATCHER.match(ua)
+        if matches
+          versions = [matches[:major]]
+          if matches[:patch]
+            versions.push(matches[:minor], matches[:patch])
+          else
+            versions.push(matches[:minor]) unless matches[:minor] == "0"
+          end
+          versions.join(".")
+        else
+          "0"
+        end
       end
 
       def name

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -51,6 +51,8 @@ IOS5: 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 
 IOS6: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25'
 IOS7: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53'
 IOS8: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A365 Safari/600.1.4'
+IOS8_1_2: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4'
+IOS8_3: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4'
 IOS9: 'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4'
 IOS_WEBVIEW: Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H141
 IPAD: 'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10'

--- a/test/unit/platform_test.rb
+++ b/test/unit/platform_test.rb
@@ -61,6 +61,27 @@ class PlatformTest < Minitest::Test
     assert_equal "9", platform.version
   end
 
+  test "detect specific minor iOS (iPhone)" do
+    platform = Browser::Platform.new(Browser["IOS8_3"])
+
+    assert_equal "iOS (iPhone)", platform.name
+    assert_equal :ios, platform.id
+    assert platform.ios?
+    assert platform.ios?(8.3)
+    assert_equal "8.3", platform.version
+  end
+
+  test "detect specific patch iOS (iPhone)" do
+    platform = Browser::Platform.new(Browser["IOS8_1_2"])
+
+    assert_equal "iOS (iPhone)", platform.name
+    assert_equal :ios, platform.id
+    assert platform.ios?
+    assert platform.ios?("8.1.2")
+    assert platform.ios?("<8.2")
+    assert_equal "8.1.2", platform.version
+  end
+
   test "detect ios (iPod Touch)" do
     platform = Browser::Platform.new(Browser["IPOD"])
 


### PR DESCRIPTION
Platform detection for iOS was checking only the Major version, not the full OS version.
This patch should provide backwards compatibility with single digit version checking.
