### PR TITLE
Format accept language code

### DIFF
--- a/lib/browser/accept_language.rb
+++ b/lib/browser/accept_language.rb
@@ -32,7 +32,10 @@ module Browser
     end
 
     def code
-      @code ||= part[/\A([^-;]+)/, 1]
+      @code ||= begin
+        code = part[/\A([^-;]+)/, 1]
+        code.downcase if code
+      end
     end
 
     def region

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+SimpleCov.start
 
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 require "bundler/setup"

--- a/test/unit/accept_language_test.rb
+++ b/test/unit/accept_language_test.rb
@@ -14,11 +14,13 @@ class AcceptLanguageTest < Minitest::Test
     assert_equal expect[:quality], item.quality, "failed quality comparison"
   end
 
+  # full
   test "returns full language" do
     language = Browser::AcceptLanguage.new("en-GB")
     assert_equal "en-GB", language.full
   end
 
+  # name
   test "returns language name" do
     language = Browser::AcceptLanguage.new("en-GB")
     assert_equal "English/United Kingdom", language.name
@@ -32,6 +34,20 @@ class AcceptLanguageTest < Minitest::Test
     assert_nil language.name
   end
 
+  # code
+  test "returns code" do
+    language = Browser::AcceptLanguage.new("en-GB")
+    assert_equal "en", language.code
+  end
+
+  test "returns formatted code" do
+    %w(EN-GB En-GB eN-GB).each do |locale|
+      language = Browser::AcceptLanguage.new(locale)
+      assert_equal "en", language.code
+    end
+  end
+
+  # new
   test "parses language with quality" do
     language = Browser::AcceptLanguage.new("en-GB;q=0.8")
     assert_language language, code: "en", region: "GB", quality: 0.8
@@ -52,6 +68,7 @@ class AcceptLanguageTest < Minitest::Test
     assert_language language, code: "az", region: "AZ", quality: 1.0
   end
 
+  # parse
   test "parses multi-language set" do
     result = Browser::AcceptLanguage.parse("fr-CA,fr;q=0.8")
 

--- a/test/unit/accept_language_test.rb
+++ b/test/unit/accept_language_test.rb
@@ -47,6 +47,24 @@ class AcceptLanguageTest < Minitest::Test
     end
   end
 
+  # region
+  test "returns region" do
+    language = Browser::AcceptLanguage.new("en-GB")
+    assert_equal "GB", language.region
+  end
+
+  test "returns formatted region" do
+    %w(en-gb en-Gb en-gB).each do |locale|
+      language = Browser::AcceptLanguage.new(locale)
+      assert_equal "GB", language.region
+    end
+  end
+
+  test "returns nil for language without region" do
+    language = Browser::AcceptLanguage.new("en")
+    assert_nil language.region
+  end
+
   # new
   test "parses language with quality" do
     language = Browser::AcceptLanguage.new("en-GB;q=0.8")

--- a/test/unit/accept_language_test.rb
+++ b/test/unit/accept_language_test.rb
@@ -41,7 +41,7 @@ class AcceptLanguageTest < Minitest::Test
   end
 
   test "returns formatted code" do
-    %w(EN-GB En-GB eN-GB).each do |locale|
+    %w[EN-GB En-GB eN-GB].each do |locale|
       language = Browser::AcceptLanguage.new(locale)
       assert_equal "en", language.code
     end
@@ -54,7 +54,7 @@ class AcceptLanguageTest < Minitest::Test
   end
 
   test "returns formatted region" do
-    %w(en-gb en-Gb en-gB).each do |locale|
+    %w[en-gb en-Gb en-gB].each do |locale|
       language = Browser::AcceptLanguage.new(locale)
       assert_equal "GB", language.region
     end

--- a/test/unit/accept_language_test.rb
+++ b/test/unit/accept_language_test.rb
@@ -4,7 +4,13 @@ require "test_helper"
 class AcceptLanguageTest < Minitest::Test
   def assert_language(item, expect = {})
     assert_equal expect[:code], item.code, "failed code comparison"
-    assert_equal expect[:region], item.region, "failed region comparison"
+
+    if expect[:region].nil?
+      assert_nil item.region, "failed region comparison"
+    else
+      assert_equal expect[:region], item.region, "failed region comparison"
+    end
+
     assert_equal expect[:quality], item.quality, "failed quality comparison"
   end
 


### PR DESCRIPTION
Currently:
```ruby
language = Browser::AcceptLanguage.new('EN-GB')

language.code 
# => "EN"

language.full
# => "EN-GB"
```

Now:
```ruby
language = Browser::AcceptLanguage.new('EN-GB')

language.code 
# => "en"

language.full
# => "en-GB"
```
