### PR TITLE
Add support for custom bots list(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Customize bots, search engines, and bots exceptions yml files
+
 ## v2.3.0
 
 - Add AWS ELB bot.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Browser used to detect empty user agents as bots, but this behavior has changed.
 Browser::Bot.detect_empty_ua!
 ```
 
+If you want to customize your list of bots, search engines, or bots exceptions, you can do so by placing your own yml file(s) in the Rails root folder. Those files will take priority over the gem's ones, which will act as a fallback.
+
 ### Middleware
 
 You can use the `Browser::Middleware` to redirect user agents.

--- a/lib/browser/bot.rb
+++ b/lib/browser/bot.rb
@@ -10,17 +10,17 @@ module Browser
     end
 
     def self.bots
-      @bots ||= YAML.load_file(Browser.root.join("bots.yml"))
+      @bots ||= YAML.load_file(preferred_path("bots.yml"))
     end
 
     def self.bot_exceptions
       @bot_exceptions ||= YAML
-                          .load_file(Browser.root.join("bot_exceptions.yml"))
+                          .load_file(preferred_path("bot_exceptions.yml"))
     end
 
     def self.search_engines
       @search_engines ||= YAML
-                          .load_file(Browser.root.join("search_engines.yml"))
+                          .load_file(preferred_path("search_engines.yml"))
     end
 
     attr_reader :ua
@@ -60,5 +60,20 @@ module Browser
     def downcased_ua
       @downcased_ua ||= ua.downcase
     end
+
+    def self.preferred_path(filename)
+      lookup_paths(filename).find {|path| File.exist?(path) }
+    end
+    private_class_method :preferred_path
+
+    def self.lookup_paths(filename)
+      # in order of priority
+      base_paths = []
+      base_paths << Rails.root if defined?(Rails)
+      base_paths << Browser.root
+
+      base_paths.map {|bp| bp.join(filename) }
+    end
+    private_class_method :lookup_paths
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+SimpleCov.start
 
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
 require "bundler/setup"


### PR DESCRIPTION
In relation to https://github.com/fnando/browser/issues/271, following the approach of the nice https://github.com/biola/Voight-Kampff gem. 

This works with all the bots configuration files currently supported by the gem:

- bots.yml
- search_engines.yml
- bots_exceptions.yml

I don't know _minitest_ very well, so I couldn't find a nice way to properly test the mechanism of priority for the YAML files to be loaded.

Another interesting point would be to organize such files in a _config_ folder (that maps Rails' structure), to avoid ending up with too many configuration files in Rails' (and the gem's) root folder. Let me know if you find this idea worth implementing.