### PR TITLE
Swapping iPhone and iPad device order to work for older Ipads

### DIFF
--- a/lib/browser/device.rb
+++ b/lib/browser/device.rb
@@ -40,8 +40,8 @@ module Browser
         PlayStation3,
         PSVita,
         PSP,
-        Iphone,
         Ipad,
+        Iphone,
         IpodTouch,
         Unknown
       ]

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -46,6 +46,7 @@ IE9: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)'
 IE9_CHROME_FRAME: 'Mozilla/5.0 (Windows NT 6.1; WOW64; chromeframe/26.0.1410.43) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.43 Safari/537.31'
 IE9_COMPAT: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/5.0)'
 IE_WITHOUT_TRIDENT: Mozilla/4.0 (compatible; MSIE8.0; Windows NT 6.0) .NET CLR 2.0.50727)
+IOS3: 'Mozilla/5.0 (iPad; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10'
 IOS4: 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7'
 IOS5: 'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3'
 IOS6: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25'

--- a/test/unit/device_test.rb
+++ b/test/unit/device_test.rb
@@ -37,6 +37,13 @@ class DeviceTest < Minitest::Test
     assert_equal "iPad", device.name
   end
 
+  test "detect old ipad" do
+    device = Browser::Device.new(Browser["IOS3"])
+    assert device.ipad?
+    assert_equal :ipad, device.id
+    assert_equal "iPad", device.name
+  end
+
   test "detect ipod" do
     device = Browser::Device.new(Browser["IPOD"])
     assert device.ipod_touch?


### PR DESCRIPTION
It's not really clear why the original device list had `Iphone` ahead of `Ipad`, but the net effect is that because `Iphone` comes first, anything that has `iPhone`--which includes iPad devices on old OS versions--while the reverse should affect nothing (e.g. no iPhone UA has ever had `iPad` in it).

I'm ambivalent about the extra test (or the `ua.yml` addition), but _does_ break on 2.3.0, and is fixed with this PR. Pretty open to any suggestions or advice, if you have any! 🍻 