### PR TITLE
Add support for QQ Browser Mac

### DIFF
--- a/lib/browser/qq.rb
+++ b/lib/browser/qq.rb
@@ -12,6 +12,8 @@ module Browser
 
     def full_version
       ua[%r[(?:Mobile MQQBrowser)/([\d.]+)]i, 1] ||
+        ua[%r[(?:QQBrowserLite)/([\d.]+)]i, 1] ||
+        ua[%r[(?:QQBrowser)/([\d.]+)]i, 1] ||
         ua[%r[(?:QQ)/([\d.]+)]i, 1] ||
         "0.0"
     end

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -125,5 +125,7 @@ WEIBO_IOS: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/60
 WEIBO_ANDROID: 'Mozilla/5.0 (Linux; Android 5.0.2; vivo X5M Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36 Weibo (vivo-vivo X5M__weibo__5.7.1__android__android5.0.2)'
 QQ_BROWSER_IOS: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13E238 QQ/6.3.3.432 V1_IPH_SQ_6.3.3_1_APP_A Pixel/640 Core/UIWebView NetType/WIFI Mem/47'
 QQ_BROWSER_ANDROID: 'Mozilla/5.0 (Linux; Android 5.1.1; SM-N9108V Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036222 Safari/537.36 V1_AND_SQ_6.2.0_320_YYB_D QQ/6.2.0.2655 NetType/WIFI WebP/0.3.0 Pixel/1440'
+QQ_BROWSER_MAC: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36 QQBrowser/4.2.4753.400'
+QQ_BROWSER_MAC_LITE: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14 QQBrowserLite/1.0.4'
 ALIPAY_IOS: "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 AliApp(AP/2.3.4) AlipayClient/2.3.4"
 ALIPAY_ANDROID: "Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; HUAWEI G610-T00 Build/HuaweiG610-T00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 AlipayDefined(nt:WIFI,ws:360|640|1.5) AliApp(AP/9.0.1.073001) AlipayClient/9.0.1.073001 GCanvas/1.4.2.15"

--- a/test/unit/qq_test.rb
+++ b/test/unit/qq_test.rb
@@ -18,4 +18,20 @@ class QQTest < Minitest::Test
     assert_equal "QQ Browser", browser.name
     assert_equal :qq, browser.id
   end
+
+  test "detects QQ browser for Mac" do
+    browser = Browser.new(Browser["QQ_BROWSER_MAC"])
+
+    assert_equal "4.2.4753.400", browser.full_version
+    assert_equal "QQ Browser", browser.name
+    assert_equal :qq, browser.id
+  end
+
+  test "detects QQ browser lite for Mac" do
+    browser = Browser.new(Browser["QQ_BROWSER_MAC_LITE"])
+
+    assert_equal "1.0.4", browser.full_version
+    assert_equal "QQ Browser", browser.name
+    assert_equal :qq, browser.id
+  end
 end


### PR DESCRIPTION
Add support for [QQ Browser for Mac](http://browser.qq.com/) and [QQ Browser Lite](https://itunes.apple.com/cn/app/qq%E6%B5%8F%E8%A7%88%E5%99%A8-lite-%E6%9E%81%E9%80%9F%E5%AE%89%E5%85%A8%E4%B8%8A%E7%BD%91%E6%B5%8F%E8%A7%88%E5%99%A8/id1178458919?l=en&mt=12)