### PR TITLE
Add support for Electron Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 doc
 log
 *.lock
+bin/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ browser = Browser.new("Some User Agent", accept_language: "en-us")
 browser.bot?
 browser.chrome?
 browser.core_media?
-browser.edge?           # Newest MS browser
+browser.edge?                # Newest MS browser
+browser.electron?            # Electron Framework
 browser.firefox?
 browser.full_version
 browser.ie?
@@ -207,7 +208,7 @@ language.name
 #=> "English/United States"
 ```
 
-Result is always sorted in quality order from highest -> lowest. As per the HTTP spec: 
+Result is always sorted in quality order from highest -> lowest. As per the HTTP spec:
 
 - omitting the quality value implies 1.0.
 - quality value equal to zero means that is not accepted by the client.

--- a/lib/browser/base.rb
+++ b/lib/browser/base.rb
@@ -174,5 +174,10 @@ module Browser
     def proxy?
       nokia? || uc_browser? || opera_mini?
     end
+
+    # Detect if the browser is Electron.
+    def electron?(expected_version = nil)
+      Electron.new(ua).match? && detect_version?(full_version, expected_version)
+    end
   end
 end

--- a/lib/browser/browser.rb
+++ b/lib/browser/browser.rb
@@ -23,6 +23,7 @@ require "browser/micro_messenger"
 require "browser/weibo"
 require "browser/qq"
 require "browser/alipay"
+require "browser/electron"
 
 require "browser/bot"
 require "browser/middleware"
@@ -53,6 +54,7 @@ module Browser
       Weibo,                # must be placed before Chrome and Safari
       QQ,                   # must be placed before Chrome and Safari
       Alipay,               # must be placed before Chrome and Safari
+      Electron,             # must be placed before Chrome and Safari
       Chrome,
       Safari,
       MicroMessenger,

--- a/lib/browser/electron.rb
+++ b/lib/browser/electron.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Browser
+  class Electron < Base
+    def id
+      :electron
+    end
+
+    def name
+      "Electron"
+    end
+
+    def full_version
+      ua[%r[Electron/([\d.]+)], 1] ||
+        "0.0"
+    end
+
+    def match?
+      ua =~ /Electron/
+    end
+  end
+end

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -127,3 +127,4 @@ QQ_BROWSER_IOS: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_1 like Mac OS X) AppleWe
 QQ_BROWSER_ANDROID: 'Mozilla/5.0 (Linux; Android 5.1.1; SM-N9108V Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile MQQBrowser/6.2 TBS/036222 Safari/537.36 V1_AND_SQ_6.2.0_320_YYB_D QQ/6.2.0.2655 NetType/WIFI WebP/0.3.0 Pixel/1440'
 ALIPAY_IOS: "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53 AliApp(AP/2.3.4) AlipayClient/2.3.4"
 ALIPAY_ANDROID: "Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; HUAWEI G610-T00 Build/HuaweiG610-T00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 AlipayDefined(nt:WIFI,ws:360|640|1.5) AliApp(AP/9.0.1.073001) AlipayClient/9.0.1.073001 GCanvas/1.4.2.15"
+ELECTRON: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Electron/1.4.12 Safari/537.36"

--- a/test/unit/electron_test.rb
+++ b/test/unit/electron_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ElectronTest < Minitest::Test
+  test "detect electron" do
+    browser = Browser.new(Browser["ELECTRON"])
+
+    assert_equal "Electron", browser.name
+    assert browser.electron?
+    assert_equal :electron, browser.id
+    assert_equal "1.4.12", browser.full_version
+  end
+end


### PR DESCRIPTION
`Electron` based apps are currently marked as `Chrome` (which is correct), but there needs to be a way to tell them apart.