### PR TITLE
Conditional use of helper_method in ActionController

### DIFF
--- a/lib/browser/action_controller.rb
+++ b/lib/browser/action_controller.rb
@@ -7,7 +7,7 @@ module Browser
     extend ActiveSupport::Concern
 
     included do
-      helper_method :browser
+      helper_method(:browser) if respond_to?(:helper_method)
     end
 
     private


### PR DESCRIPTION
In controllers inherited from `ActionController:API`, we don't have available the `helper_method` method.