### PR TITLE
Detect Opera by checking for 'OPR/' instead of 'OPR' so Android Oreo is not falsely detected as Opera.

### DIFF
--- a/lib/browser/opera.rb
+++ b/lib/browser/opera.rb
@@ -15,7 +15,7 @@ module Browser
     end
 
     def match?
-      ua =~ /(Opera|OPR)/
+      ua =~ /(Opera|OPR\/)/
     end
   end
 end

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -16,6 +16,7 @@ ANDROID_KITKAT: Mozilla/5.0 (Linux; Android 4.4; Nexus 7 Build/KOT24) AppleWebKi
 ANDROID_LOLLIPOP_50: Mozilla/5.0 (Linux; Android 5.0; Nexus 5 Build/LPX13D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Mobile Safari/537.36
 ANDROID_LOLLIPOP_51: Mozilla/5.0 (Linux; Android 5.1; Nexus 5 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.0.0 Mobile Safari/537.36; DailymotionEmbedSDK 1.0
 ANDROID_NEXUS_PLAYER: Mozilla/5.0 (Linux; Android 5.0; Nexus Player Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.0
+ANDROID_OREO: Mozilla/5.0 (Linux; Android 8.0.0; Pixel Build/OPR6.170623.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.03112.107 Mobile Safari/537.36
 ANDROID_TV: Mozilla/5.0 (Linux; Android 5.0; ADT-1 Build/LRW87K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
 ANDROID_WEBVIEW: Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36
 ANDROID_WITH_SAFARI: 'Mozilla/5.0 (Linux; U; Android 4.3; en-us; SCH-I535 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'

--- a/test/unit/android_test.rb
+++ b/test/unit/android_test.rb
@@ -81,6 +81,12 @@ class AndroidTest < Minitest::Test
     assert browser.platform.android?(5.1)
   end
 
+  test "detect android oreo (8.0)" do
+    browser = Browser.new(Browser["ANDROID_OREO"])
+    assert browser.platform.android?
+    assert browser.platform.android?(8.0)
+  end
+
   test "detect android tv" do
     browser = Browser.new(Browser["ANDROID_TV"])
     assert browser.platform.android?

--- a/test/unit/chrome_test.rb
+++ b/test/unit/chrome_test.rb
@@ -71,6 +71,12 @@ class ChromeTest < Minitest::Test
     assert_equal "26", browser.version
   end
 
+  test "detects chrome not opera when android build number contains 'Pixel Build/OPR'" do
+    browser = Browser.new(Browser["ANDROID_OREO"])
+
+    assert browser.chrome?
+  end
+
   test "detects version by range" do
     browser = Browser.new(Browser["CHROME"])
     assert browser.chrome?(%w[>=5 <6])

--- a/test/unit/chrome_test.rb
+++ b/test/unit/chrome_test.rb
@@ -71,7 +71,7 @@ class ChromeTest < Minitest::Test
     assert_equal "26", browser.version
   end
 
-  test "detects chrome not opera when android build number contains 'Pixel Build/OPR'" do
+  test "detects chrome not opera when android build number contains 'OPR'" do
     browser = Browser.new(Browser["ANDROID_OREO"])
 
     assert browser.chrome?


### PR DESCRIPTION
e.g. for user agents like '...Android 8.0.0; Pixel Build/OPR6...'.