### PR TITLE
Lazy load ActionController::Base

### DIFF
--- a/lib/browser/rails.rb
+++ b/lib/browser/rails.rb
@@ -11,8 +11,10 @@ module Browser
     initializer "browser" do
       ActiveSupport.on_load(:action_controller) do
         ::ActionController::Base.send :include, Browser::ActionController
-        Browser::Middleware::Context.send :include,
-                                          Browser::Middleware::Context::Additions
+        Browser::Middleware::Context.send(
+          :include,
+          Browser::Middleware::Context::Additions
+        )
       end
     end
   end

--- a/lib/browser/rails.rb
+++ b/lib/browser/rails.rb
@@ -9,9 +9,11 @@ module Browser
     config.browser = ActiveSupport::OrderedOptions.new
 
     initializer "browser" do
-      ::ActionController::Base.send :include, Browser::ActionController
-      Browser::Middleware::Context.send :include,
-                                        Browser::Middleware::Context::Additions
+      ActiveSupport.on_load(:action_controller) do
+        ::ActionController::Base.send :include, Browser::ActionController
+        Browser::Middleware::Context.send :include,
+                                          Browser::Middleware::Context::Additions
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, users cannot configure ActionController in initializers when
they use browser gem because browser gem loads ActionController::Base
too early.