### PR TITLE
Descending priority for accept languages

### DIFF
--- a/browser.gemspec
+++ b/browser.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rails"
-  s.add_development_dependency "rack-test"
+  s.add_development_dependency "rack-test", "~> 0.8.3"
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-utils"
   s.add_development_dependency "pry-meta"

--- a/browser.gemspec
+++ b/browser.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", ">= 0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rails"
-  s.add_development_dependency "rack-test", "~> 0.8.3"
+  s.add_development_dependency "rack-test", "< 1.0"
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-utils"
   s.add_development_dependency "pry-meta"

--- a/lib/browser/accept_language.rb
+++ b/lib/browser/accept_language.rb
@@ -14,8 +14,7 @@ module Browser
         .map {|string| string.squeeze(" ").strip }
         .map {|part| new(part) }
         .reject {|al| al.quality.zero? }
-        .sort_by(&:quality)
-        .reverse
+        .sort_by.with_index {|al, idx| [-al.quality, idx] }
     end
 
     attr_reader :part

--- a/test/unit/accept_language_test.rb
+++ b/test/unit/accept_language_test.rb
@@ -131,6 +131,16 @@ class AcceptLanguageTest < Minitest::Test
     assert_language result[4], code: "fr", region: nil, quality: 0.2
   end
 
+  test "sorts the same quality in a descending priority" do
+    accept_language = "fr-CA,fr;q=0.2,en-US;q=0.2,en"
+    result = Browser::AcceptLanguage.parse(accept_language)
+
+    assert_language result[0], code: "fr", region: "CA", quality: 1.0
+    assert_language result[1], code: "en", region: nil, quality: 1.0
+    assert_language result[2], code: "fr", region: nil, quality: 0.2
+    assert_language result[3], code: "en", region: "US", quality: 0.2
+  end
+
   test "rejects quality values equals to zero (#241)" do
     result = Browser::AcceptLanguage.parse("de-DE,ru;q=0.9,de;q=0.8,en;q=0.")
 


### PR DESCRIPTION
I guess to change the sorting for accept languages which have the same quality values.

For example, if HTTP-header has value `en,fr` (without qualities) the first language in a row should be `en`. Nowadays it is `fr`. 

There are no strict requirements for this behavior but based on other libraries which I have seen and RFC7231 it seems to be the more expected result:

> Note that some recipients treat the order in which language tags are listed as an indication of descending priority, particularly for tags that are assigned equal quality values (no value is the same as q=1).
https://tools.ietf.org/html/rfc7231#section-5.3.5

BTW, the 1.0 version of `rack-task` has a bug about working with sessions, so I had to keep older version of this gem to test this pull-request.