### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,13 +100,11 @@ DotPosition:
 SpaceBeforeBlockBraces:
   EnforcedStyle: space
 
-SpaceInsideBlockBraces:
-  EnforcedStyle: no_space
-
 DoubleNegation:
   Enabled: false
 
 SpaceInsideBlockBraces:
+  EnforcedStyle: no_space
   SpaceBeforeBlockParameters: false
 
 SpaceInsideHashLiteralBraces:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - "Rakefile"
     - "*.gemspec"
     - "config.ru"
+    - "lib/browser/version.rb"
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method

--- a/lib/browser/accept_language.rb
+++ b/lib/browser/accept_language.rb
@@ -35,14 +35,14 @@ module Browser
     def code
       @code ||= begin
         code = part[/\A([^-;]+)/, 1]
-        code.downcase if code
+        code&.downcase
       end
     end
 
     def region
       @region ||= begin
         region = part[/\A(?:.*?)-([^;-]+)/, 1]
-        region.upcase if region
+        region&.upcase
       end
     end
 

--- a/lib/browser/accept_language.rb
+++ b/lib/browser/accept_language.rb
@@ -48,10 +48,10 @@ module Browser
 
     def quality
       @quality ||= begin
-        Float(quality_value || 1.0)
-      rescue ArgumentError
-        0.1
-      end
+                     Float(quality_value || 1.0)
+                   rescue ArgumentError
+                     0.1
+                   end
     end
 
     private

--- a/lib/browser/bot.rb
+++ b/lib/browser/bot.rb
@@ -41,6 +41,7 @@ module Browser
     def name
       return unless bot?
       return "Generic Bot" if bot_with_empty_ua?
+
       self.class.bots.find {|key, _| downcased_ua.include?(key) }.last
     end
 

--- a/lib/browser/browser.rb
+++ b/lib/browser/browser.rb
@@ -35,7 +35,7 @@ require "browser/device"
 require "browser/meta"
 
 module Browser
-  EMPTY_STRING = "".freeze
+  EMPTY_STRING = ""
 
   def self.root
     @root ||= Pathname.new(File.expand_path("../..", __dir__))

--- a/lib/browser/middleware.rb
+++ b/lib/browser/middleware.rb
@@ -6,10 +6,12 @@ require "browser/middleware/context"
 module Browser
   class Middleware
     # Detect the most common assets.
-    ASSETS_REGEX = /\.(css|png|jpe?g|gif|js|svg|ico|flv|mov|m4v|ogg|swf)\z/i
+    # rubocop:disable Metrics/LineLength
+    ASSETS_REGEX = /\.(css|png|jpe?g|gif|js|svg|ico|flv|mov|m4v|ogg|swf)\z/.freeze
+    # rubocop:enable Metrics/LineLength
 
     # Detect the ACCEPT header. IE8 send */*.
-    ACCEPT_REGEX = %r[(text/html|\*/\*)]
+    ACCEPT_REGEX = %r[(text/html|\*/\*)].freeze
 
     def initialize(app, &block)
       raise ArgumentError, "Browser::Middleware requires a block" unless block

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -3,8 +3,8 @@
 module Browser
   class Platform
     class IOS < Base
-      MATCHER = /(iPhone|iPad|iPod)/
-      VERSION_MATCHER = /OS ([\d.]+)/
+      MATCHER = /(iPhone|iPad|iPod)/.freeze
+      VERSION_MATCHER = /OS ([\d.]+)/.freeze
 
       def version
         ua[VERSION_MATCHER, 1] || "0"


### PR DESCRIPTION
### Style/SafeNavigation
Style/SafeNavigation: Use safe navigation (&.) instead of checking if an object exists before calling the method.

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SafeNavigation

```
# bad
foo.bar if foo

# good
foo&.bar
```

### Layout/RescueEnsureAlignment
Layout/RescueEnsureAlignment: rescue at 52, 6 is not aligned with begin at 50, 19.

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/RescueEnsureAlignment

```
# bad
begin
  something
  rescue
  puts 'error'
end

# good
begin
  something
rescue
  puts 'error'
end
```

## Style/MutableConstant
Style/MutableConstant: Freeze mutable objects assigned to constants.

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/MutableConstant

```
# bad
CONST = [1, 2, 3]

# good
CONST = [1, 2, 3].freeze
```

## Style/RedundantFreeze
Style/RedundantFreeze: Do not freeze immutable objects, as freezing them has no effect.

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RedundantFreeze

```
# bad
CONST = 1.freeze

# good
CONST = 1
```

## Layout/EmptyLineAfterGuardClause
Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.

ref: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/EmptyLineAfterGuardClause

```
# bad
def foo
  return if need_return?
  bar
end

# good
def foo
  return if need_return?

  bar
end
```
