### PR TITLE
Changed return value of boolean method from nil to boolean value

### DIFF
--- a/lib/browser/accept_language.rb
+++ b/lib/browser/accept_language.rb
@@ -35,23 +35,24 @@ module Browser
     def code
       @code ||= begin
         code = part[/\A([^-;]+)/, 1]
-        code.downcase if code
+        code&.downcase
       end
     end
 
     def region
       @region ||= begin
         region = part[/\A(?:.*?)-([^;-]+)/, 1]
-        region.upcase if region
+        region&.upcase
       end
     end
 
     def quality
-      @quality ||= begin
-        Float(quality_value || 1.0)
-      rescue ArgumentError
-        0.1
-      end
+      @quality ||=
+        begin
+          Float(quality_value || 1.0)
+        rescue ArgumentError
+          0.1
+        end
     end
 
     private

--- a/lib/browser/base.rb
+++ b/lib/browser/base.rb
@@ -57,13 +57,13 @@ module Browser
 
     # Detect if browser is Microsoft Internet Explorer.
     def ie?(expected_version = nil)
-      InternetExplorer.new(ua).match? &&
+      !!(InternetExplorer.new(ua).match?) &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Microsoft Edge.
     def edge?(expected_version = nil)
-      Edge.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Edge.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     def compatibility_view?
@@ -80,98 +80,98 @@ module Browser
 
     # Detect if browser if Facebook.
     def facebook?(expected_version = nil)
-      Facebook.new(ua).match? &&
+      !!(Facebook.new(ua).match?) &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Otter.
     def otter?(expected_version = nil)
-      Otter.new(ua).match? &&
+      !!(Otter.new(ua).match?) &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is WebKit-based.
     def webkit?(expected_version = nil)
-      ua =~ /AppleWebKit/i &&
+      !!(ua =~ /AppleWebKit/i) &&
         !edge? &&
         detect_version?(webkit_full_version, expected_version)
     end
 
     # Detect if browser is QuickTime
     def quicktime?(expected_version = nil)
-      ua =~ /QuickTime/i && detect_version?(full_version, expected_version)
+      !!(ua =~ /QuickTime/i) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Apple CoreMedia.
     def core_media?(expected_version = nil)
-      ua =~ /CoreMedia/ && detect_version?(full_version, expected_version)
+      !!(ua =~ /CoreMedia/) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is PhantomJS
     def phantom_js?(expected_version = nil)
-      PhantomJS.new(ua).match? &&
+      !!(PhantomJS.new(ua).match?) &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Safari.
     def safari?(expected_version = nil)
-      Safari.new(ua).match? && detect_version?(version, expected_version)
+      !!(Safari.new(ua).match?) && detect_version?(version, expected_version)
     end
 
     def safari_webapp_mode?
-      (device.ipad? || device.iphone?) && ua =~ /AppleWebKit/
+      (device.ipad? || device.iphone?) && !!(ua =~ /AppleWebKit/)
     end
 
     # Detect if browser is Firefox.
     def firefox?(expected_version = nil)
-      Firefox.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Firefox.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Chrome.
     def chrome?(expected_version = nil)
-      Chrome.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Chrome.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Opera.
     def opera?(expected_version = nil)
-      Opera.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Opera.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Yandex.
     def yandex?(expected_version = nil)
-      ua =~ /YaBrowser/ && detect_version?(full_version, expected_version)
+      !!(ua =~ /YaBrowser/) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is UCBrowser.
     def uc_browser?(expected_version = nil)
-      UCBrowser.new(ua).match? &&
+      !!(UCBrowser.new(ua).match?) &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Nokia S40 Ovi Browser.
     def nokia?(expected_version = nil)
-      Nokia.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Nokia.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is MicroMessenger.
     def micro_messenger?(expected_version = nil)
-      MicroMessenger.new(ua).match? &&
+      !!(MicroMessenger.new(ua).match?) &&
         detect_version?(full_version, expected_version)
     end
 
     alias_method :wechat?, :micro_messenger?
 
     def weibo?(expected_version = nil)
-      Weibo.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Weibo.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     def alipay?(expected_version = nil)
-      Alipay.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Alipay.new(ua).match?) && detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Opera Mini.
     def opera_mini?(expected_version = nil)
-      ua =~ /Opera Mini/ && detect_version?(full_version, expected_version)
+      !!(ua =~ /Opera Mini/) && detect_version?(full_version, expected_version)
     end
 
     def webkit_full_version
@@ -189,7 +189,7 @@ module Browser
 
     # Detect if the browser is Electron.
     def electron?(expected_version = nil)
-      Electron.new(ua).match? && detect_version?(full_version, expected_version)
+      !!(Electron.new(ua).match?) && detect_version?(full_version, expected_version)
     end
   end
 end

--- a/lib/browser/base.rb
+++ b/lib/browser/base.rb
@@ -57,13 +57,13 @@ module Browser
 
     # Detect if browser is Microsoft Internet Explorer.
     def ie?(expected_version = nil)
-      !!(InternetExplorer.new(ua).match?) &&
+      !!InternetExplorer.new(ua).match? &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Microsoft Edge.
     def edge?(expected_version = nil)
-      !!(Edge.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Edge.new(ua).match? && detect_version?(full_version, expected_version)
     end
 
     def compatibility_view?
@@ -80,13 +80,13 @@ module Browser
 
     # Detect if browser if Facebook.
     def facebook?(expected_version = nil)
-      !!(Facebook.new(ua).match?) &&
+      !!Facebook.new(ua).match? &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Otter.
     def otter?(expected_version = nil)
-      !!(Otter.new(ua).match?) &&
+      !!Otter.new(ua).match? &&
         detect_version?(full_version, expected_version)
     end
 
@@ -99,79 +99,91 @@ module Browser
 
     # Detect if browser is QuickTime
     def quicktime?(expected_version = nil)
-      !!(ua =~ /QuickTime/i) && detect_version?(full_version, expected_version)
+      !!(ua =~ /QuickTime/i) &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Apple CoreMedia.
     def core_media?(expected_version = nil)
-      !!(ua =~ /CoreMedia/) && detect_version?(full_version, expected_version)
+      !!(ua =~ /CoreMedia/) &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is PhantomJS
     def phantom_js?(expected_version = nil)
-      !!(PhantomJS.new(ua).match?) &&
+      !!PhantomJS.new(ua).match? &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Safari.
     def safari?(expected_version = nil)
-      !!(Safari.new(ua).match?) && detect_version?(version, expected_version)
+      !!Safari.new(ua).match? &&
+        detect_version?(version, expected_version)
     end
 
     def safari_webapp_mode?
-      (device.ipad? || device.iphone?) && !!(ua =~ /AppleWebKit/)
+      (device.ipad? || device.iphone?) &&
+        !!(ua =~ /AppleWebKit/)
     end
 
     # Detect if browser is Firefox.
     def firefox?(expected_version = nil)
-      !!(Firefox.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Firefox.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Chrome.
     def chrome?(expected_version = nil)
-      !!(Chrome.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Chrome.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Opera.
     def opera?(expected_version = nil)
-      !!(Opera.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Opera.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Yandex.
     def yandex?(expected_version = nil)
-      !!(ua =~ /YaBrowser/) && detect_version?(full_version, expected_version)
+      !!(ua =~ /YaBrowser/) &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is UCBrowser.
     def uc_browser?(expected_version = nil)
-      !!(UCBrowser.new(ua).match?) &&
+      !!UCBrowser.new(ua).match? &&
         detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Nokia S40 Ovi Browser.
     def nokia?(expected_version = nil)
-      !!(Nokia.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Nokia.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is MicroMessenger.
     def micro_messenger?(expected_version = nil)
-      !!(MicroMessenger.new(ua).match?) &&
+      !!MicroMessenger.new(ua).match? &&
         detect_version?(full_version, expected_version)
     end
 
     alias_method :wechat?, :micro_messenger?
 
     def weibo?(expected_version = nil)
-      !!(Weibo.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Weibo.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
 
     def alipay?(expected_version = nil)
-      !!(Alipay.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Alipay.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
 
     # Detect if browser is Opera Mini.
     def opera_mini?(expected_version = nil)
-      !!(ua =~ /Opera Mini/) && detect_version?(full_version, expected_version)
+      !!(ua =~ /Opera Mini/) &&
+        detect_version?(full_version, expected_version)
     end
 
     def webkit_full_version
@@ -189,7 +201,8 @@ module Browser
 
     # Detect if the browser is Electron.
     def electron?(expected_version = nil)
-      !!(Electron.new(ua).match?) && detect_version?(full_version, expected_version)
+      !!Electron.new(ua).match? &&
+        detect_version?(full_version, expected_version)
     end
   end
 end

--- a/lib/browser/bot.rb
+++ b/lib/browser/bot.rb
@@ -41,6 +41,7 @@ module Browser
     def name
       return unless bot?
       return "Generic Bot" if bot_with_empty_ua?
+
       self.class.bots.find {|key, _| downcased_ua.include?(key) }.last
     end
 

--- a/lib/browser/browser.rb
+++ b/lib/browser/browser.rb
@@ -35,7 +35,7 @@ require "browser/device"
 require "browser/meta"
 
 module Browser
-  EMPTY_STRING = "".freeze
+  EMPTY_STRING = ""
 
   def self.root
     @root ||= Pathname.new(File.expand_path("../..", __dir__))

--- a/lib/browser/middleware.rb
+++ b/lib/browser/middleware.rb
@@ -6,10 +6,11 @@ require "browser/middleware/context"
 module Browser
   class Middleware
     # Detect the most common assets.
-    ASSETS_REGEX = /\.(css|png|jpe?g|gif|js|svg|ico|flv|mov|m4v|ogg|swf)\z/i
+    ASSETS_REGEX =
+      /\.(css|png|jpe?g|gif|js|svg|ico|flv|mov|m4v|ogg|swf)\z/i.freeze
 
     # Detect the ACCEPT header. IE8 send */*.
-    ACCEPT_REGEX = %r[(text/html|\*/\*)]
+    ACCEPT_REGEX = %r[(text/html|\*/\*)].freeze
 
     def initialize(app, &block)
       raise ArgumentError, "Browser::Middleware requires a block" unless block

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -3,8 +3,8 @@
 module Browser
   class Platform
     class IOS < Base
-      MATCHER = /(iPhone|iPad|iPod)/
-      VERSION_MATCHER = /OS ([\d.]+)/
+      MATCHER = /(iPhone|iPad|iPod)/.freeze
+      VERSION_MATCHER = /OS ([\d.]+)/.freeze
 
       def version
         ua[VERSION_MATCHER, 1] || "0"

--- a/lib/browser/version.rb
+++ b/lib/browser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Browser
-  VERSION = "2.5.3".freeze
+  VERSION = "2.5.3"
 end


### PR DESCRIPTION
## Summary
- I made boolean method appropriate. https://github.com/fnando/browser/pull/379/commits/8ef8400730d66ddeccbdad1e609b863c313377db
ex: `firefox?`
- I also fixed offenses of rubocop. https://github.com/fnando/browser/pull/379/commits/1cac5944acf9733494407069bfb1223e7c963e42

## Before
To give an example, when  you accessed a website by Chrome.
Boolean methods will return nil except for case of Chrome.

```console
$ browser = Browser.new(request.env['HTTP_USER_AGENT'])
$ browser.firefox?
=> nil
```

## After

```console
$ browser = Browser.new(request.env['HTTP_USER_AGENT'])
$ browser.firefox?
=> false
```
