### PR TITLE
Feature/correspond to the api mode

### DIFF
--- a/lib/browser/rails.rb
+++ b/lib/browser/rails.rb
@@ -10,7 +10,7 @@ module Browser
 
     initializer "browser" do
       ActiveSupport.on_load(:action_controller) do
-        ::ActionController::Base.send :include, Browser::ActionController
+        ::ActionController::Metal.send :include, Browser::ActionController
         Browser::Middleware::Context.send(
           :include,
           Browser::Middleware::Context::Additions

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -19,4 +19,14 @@ class RailsTest < Minitest::Test
     assert_equal 200, last_response.status
     assert_equal "Chrome:en-US", last_response.body
   end
+
+  test "renders json" do
+    get "/api/pages", {}, "HTTP_USER_AGENT" => Browser["COMMONCRAWL"],
+                          "HTTP_ACCEPT" => "application/json",
+                          "HTTP_ACCEPT_LANGUAGE" => "en-US;q=0.8"
+
+    assert_equal 200, last_response.status
+    assert_equal true, JSON.parse(last_response.body)["isBot"]
+    assert_equal "en-US", JSON.parse(last_response.body)["acceptLanguages"][0]
+  end
 end

--- a/test/sample_app.rb
+++ b/test/sample_app.rb
@@ -9,6 +9,15 @@ class PagesController < ActionController::Base
   end
 end
 
+class PotsController < ActionController::API
+  def index
+    render json: {
+      isBot: browser.bot?,
+      acceptLanguages: browser.accept_language.map(&:full)
+    }
+  end
+end
+
 class SampleApp < Rails::Application
   config.secret_token = "99f19f08db7a37bdcb9d6701f54dca"
   config.secret_key_base = "99f19f08db7a37bdcb9d6701f54dca"
@@ -29,6 +38,8 @@ class SampleApp < Rails::Application
     }
 
     get "/home", to: "pages#home"
+
+    get "/api/pages", to: "pots#index"
   end
 
   config.middleware.use Browser::Middleware do


### PR DESCRIPTION
This transparently applies the browser to rails-api.

**Before**
```ruby
class PotsController < ActionController::API
  def index
    browser.bot? #=> Be encountered NameError
  end
end
```

**After**
```ruby
class PotsController < ActionController::API
  def index
    browser.bot? #=> Transparently accesses Browser!
  end
end
```