### PR TITLE
Fix detection of instagram browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Handle instagram user agents that have a slash instead of a space
+
 ## 2.6.1
 
 - Also include controller extensions to `ActionController::Base`.

--- a/lib/browser/instagram.rb
+++ b/lib/browser/instagram.rb
@@ -11,7 +11,7 @@ module Browser
     end
 
     def full_version
-      ua[%r[Instagram ([\d.]+)], 1]
+      ua[%r[Instagram[ /]([\d.]+)], 1]
     end
 
     def match?

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -55,6 +55,7 @@ IE9_CHROME_FRAME: "Mozilla/5.0 (Windows NT 6.1; WOW64; chromeframe/26.0.1410.43)
 IE9_COMPAT: "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/5.0)"
 IE_WITHOUT_TRIDENT: Mozilla/4.0 (compatible; MSIE8.0; Windows NT 6.0) .NET CLR 2.0.50727)
 INSTAGRAM: "Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E216 Instagram 41.0.0.14.90 (iPhone9,3; iOS 11_3; pl_PL; pl-PL; scale=2.00; gamut=wide; 750x1334)"
+INSTAGRAM_OTHER: "Instagram/182257141 CFNetwork/1107.1 Darwin/19.0.0"
 IOS3: "Mozilla/5.0 (iPad; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10"
 IOS4: "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7"
 IOS5: "Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3"

--- a/test/unit/instagram_test.rb
+++ b/test/unit/instagram_test.rb
@@ -13,6 +13,16 @@ class InstagramTest < Minitest::Test
     assert_equal "41", browser.version
   end
 
+  test "detects alternate instagram user agent" do
+    browser = Browser.new(Browser["INSTAGRAM_OTHER"])
+
+    assert_equal "Instagram", browser.name
+    assert browser.instagram?
+    assert :instagram, browser.id
+    assert_equal "182257141", browser.full_version
+    assert_equal "182257141", browser.version
+  end
+
   test "detects version by range" do
     browser = Browser.new(Browser["INSTAGRAM"])
     assert browser.instagram?(%w[>=41])


### PR DESCRIPTION
While using this, we came across a user agent that took the form:
Instagram/182257141 CFNetwork/1107.1 Darwin/19.0.0

This is matched by the instagram matcher, but can't be parsed because it
assumes that there will be a space following Instagram. This updates it
to look for a space or a slash.