### PR TITLE
Handle Snapchat UAs that have a space or an empty string before version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Handle Snapchat user agents that have a space or an empty string instead of a slash before the version.
 - Add more Slack bots.
 - Handle instagram user agents that have a slash instead of a space.
 - Add `Browser::Bot.why?(ua)` to help debugging why a user agent is considered bot.

--- a/lib/browser/snapchat.rb
+++ b/lib/browser/snapchat.rb
@@ -11,7 +11,7 @@ module Browser
     end
 
     def full_version
-      ua[%r[Snapchat/([\d.]+)], 1]
+      ua[%r[Snapchat( ?|/)([\d.]+)], 2]
     end
 
     def match?

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -120,6 +120,8 @@ SAMSUNG: "Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SAMSUNG-SGH-I497 Build/IM
 SAMSUNG_CHROME: "Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG GT-I9195/I9195XXUCNEA Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36"
 SMART_TV: "Mozilla/5.0 (SmartHub; SMART-TV; U; Linux/SmartTV) AppleWebKit/531.2+ (KHTML, like Gecko) WebBrowser/1.0 SmartTV Safari/531.2+"
 SNAPCHAT: Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Snapchat/10.69.5.72 (iPhone10,3; iOS 13.2.2; gzip)
+SNAPCHAT_SPACE_VERSION: "Mozilla/5.0 (Linux; Android 9; SM-N960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36Snapchat 10.70.0.0 (SM-N960U; Android 9#N960USQS3CSJ2#28; gzip)"
+SNAPCHAT_EMPTY_STRING_VERSION: "Mozilla/5.0 (Linux; Android 9; SM-N960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36Snapchat10.70.0.0 (SM-N960U; Android 9#N960USQS3CSJ2#28; gzip)"
 SPUTNIK: "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 SputnikBrowser/4.1.2801.0 Safari/537.36"
 SURFACE: "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)"
 SYMBIAN: "Nokia5250/10.0.011 (SymbianOS/9.4; U; Series60/5.0 Mozilla/5.0; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Safari/525 3gpp-gba"

--- a/test/unit/snapchat_test.rb
+++ b/test/unit/snapchat_test.rb
@@ -13,6 +13,26 @@ class SnapchatTest < Minitest::Test
     assert_equal "10", browser.version
   end
 
+  test "detects snapchat for badly formatted user agent" do
+    browser = Browser.new(Browser["SNAPCHAT_EMPTY_STRING_VERSION"])
+
+    assert_equal "Snapchat", browser.name
+    assert browser.snapchat?
+    assert :snapchat, browser.id
+    assert_equal "10.70.0.0", browser.full_version
+    assert_equal "10", browser.version
+  end
+
+  test "detects alternate snapchat user agent" do
+    browser = Browser.new(Browser["SNAPCHAT_SPACE_VERSION"])
+
+    assert_equal "Snapchat", browser.name
+    assert browser.snapchat?
+    assert :snapchat, browser.id
+    assert_equal "10.70.0.0", browser.full_version
+    assert_equal "10", browser.version
+  end
+
   test "detects version by range" do
     browser = Browser.new(Browser["SNAPCHAT"])
     assert browser.snapchat?(%w[>=10])


### PR DESCRIPTION
While using this we came across a badly formatted user agent like this: `Mozilla/5.0 (Linux; Android 9; SM-N960U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36Snapchat10.70.0.0 (SM-N960U; Android 9#N960USQS3CSJ2#28; gzip)`

This is matched by the Snapchat matcher, but it can't parse version because it assumes there will be a space following "Snapchat". This updates it to look for a space, empty string, or a slash.