### PR TITLE
Add fallback versions for instagram and snapchat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Handle Snapchat user agents that have a space or an empty string instead of a slash before the version.
+- Add fallback versions for instagram and snapchat to avoid NoMethodErrors on unexpected user agents.
 
 ## 2.7.0
 

--- a/lib/browser/instagram.rb
+++ b/lib/browser/instagram.rb
@@ -11,7 +11,7 @@ module Browser
     end
 
     def full_version
-      ua[%r[Instagram[ /]([\d.]+)], 1]
+      ua[%r[Instagram[ /]([\d.]+)], 1] || "0.0"
     end
 
     def match?

--- a/lib/browser/snapchat.rb
+++ b/lib/browser/snapchat.rb
@@ -11,7 +11,7 @@ module Browser
     end
 
     def full_version
-      ua[%r[Snapchat( ?|/)([\d.]+)], 2]
+      ua[%r[Snapchat( ?|/)([\d.]+)], 2] || "0.0"
     end
 
     def match?


### PR DESCRIPTION
All other browsers have these, but instagram and snapchat do not, and this has proven to be very error-prone.