### PR TITLE
Fix iOS 10+ version detection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/LineLength:
-  Enabled: 80
+  Max: 80
 
 Metrics/MethodLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 80
+  Enabled: false
 
 Metrics/MethodLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/LineLength:
-  Enabled: false
+  Enabled: 80
 
 Metrics/MethodLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Handle Snapchat user agents that have a space or an empty string instead of a slash before the version.
+- Fix iOS 10+ version detection.
 
 ## 2.7.0
 

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -4,7 +4,7 @@ module Browser
   class Platform
     class IOS < Base
       MATCHER = /(iPhone|iPad|iPod)/.freeze
-      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d)_?(?<patch>\d)?)/.freeze
+      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d+)_?(?<patch>\d+)?)/.freeze
 
       def version
         matches = VERSION_MATCHER.match(ua)

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -4,7 +4,7 @@ module Browser
   class Platform
     class IOS < Base
       MATCHER = /(iPhone|iPad|iPod)/.freeze
-      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d+)_?(?<patch>\d+)?)/.freeze
+      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d+)_?(?<patch>\d+)?)/.freeze  # rubocop:disable Metrics/LineLength
 
       def version
         matches = VERSION_MATCHER.match(ua)

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -4,7 +4,7 @@ module Browser
   class Platform
     class IOS < Base
       MATCHER = /(iPhone|iPad|iPod)/.freeze
-      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d+)_?(?<patch>\d+)?)/.freeze  # rubocop:disable Metrics/LineLength
+      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d+)_?(?<patch>\d+)?)/.freeze # rubocop:disable Metrics/LineLength
 
       def version
         matches = VERSION_MATCHER.match(ua)

--- a/lib/browser/platform/ios.rb
+++ b/lib/browser/platform/ios.rb
@@ -4,7 +4,7 @@ module Browser
   class Platform
     class IOS < Base
       MATCHER = /(iPhone|iPad|iPod)/.freeze
-      VERSION_MATCHER = /OS ((?<major>\d)_(?<minor>\d)_?(?<patch>\d)?)/.freeze
+      VERSION_MATCHER = /OS ((?<major>\d+)_(?<minor>\d)_?(?<patch>\d)?)/.freeze
 
       def version
         matches = VERSION_MATCHER.match(ua)

--- a/test/ua.yml
+++ b/test/ua.yml
@@ -66,6 +66,7 @@ IOS8: "Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.4
 IOS8_1_2: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_1_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B440 Safari/600.1.4'
 IOS8_3: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12F70 Safari/600.1.4'
 IOS9: "Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4"
+IOS12: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
 IOS_WEBVIEW: Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12H141
 IPAD: "Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10"
 IPHONE: "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/420.1 (KHTML, like Gecko) Version/3.0 Mobile/1A542a Safari/419.3"

--- a/test/unit/ios_test.rb
+++ b/test/unit/ios_test.rb
@@ -105,6 +105,13 @@ class IosTest < Minitest::Test
     refute browser.platform.mac?
   end
 
+  test "detects ios12" do
+    browser = Browser.new(Browser["IOS12"])
+    assert browser.platform.ios?
+    assert browser.platform.ios?(12)
+    refute browser.platform.mac?
+  end
+
   test "don't detect as two different versions" do
     browser = Browser.new(Browser["IOS8"])
     assert browser.platform.ios?(8)


### PR DESCRIPTION
iOS 10+ is always detected as `0` because the regex does not match two-digit numbers.

This is a regression introduced in https://github.com/fnando/browser/commit/2eca1f04e20b1f740b5ec773d52bdaa3ed7ffbc9#diff-9d41eb017f6992f4da43a01f665aa17dR7 (version 2.7.0)