### PR TITLE
Remove the .bundle directory

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_BIN: bin

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc
 log
 *.lock
 bin/
+.bundle


### PR DESCRIPTION
This directory gets included in the generated gems and is breaking some automation of ours. One option would be to exclude it in the gemspec, but bundler [explicitly says the directory should not be committed](https://bundler.io/v2.0/guides/bundler_sharing.html) in the first place:

> Do not check in the .bundle directory or any of the files inside it. Those files are specific to each particular machine and are used to persist installation options between runs of the bundle install command.

So even though the automation is specific to us, it seems like a best practice to adopt? 