### PR TITLE
Add changelog to gemspec

### DIFF
--- a/browser.gemspec
+++ b/browser.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.description           = s.summary
   s.license               = "MIT"
 
+  s.metadata["changelog_uri"] = "https://github.com/fnando/browser/blob/master/CHANGELOG.md"
+  
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- exe/*`


### PR DESCRIPTION
For a nice “Changelog” link in the https://rubygems.org/gems/browser sidebar.