### PR TITLE
Samsung Browser should not be identified as Safari

### DIFF
--- a/lib/browser/safari.rb
+++ b/lib/browser/safari.rb
@@ -22,6 +22,7 @@ module Browser
         ua !~ /PhantomJS|FxiOS/ &&
         !edge? &&
         !chrome? &&
+        !samsung_browser? &&
         !duck_duck_go? &&
         !yandex? &&
         !sputnik?

--- a/test/unit/samsung_browser_test.rb
+++ b/test/unit/samsung_browser_test.rb
@@ -13,6 +13,7 @@ class SamsungBrowserTest < Minitest::Test
     assert_equal "11.1", browser.full_version
     assert_equal "Samsung Browser", browser.name
     refute browser.chrome?
+    refute browser.safari?
   end
 
   test "detects version by range" do


### PR DESCRIPTION
This PR fixes the problem where `browser.safari?` would return `true` when the client has Samsung Browser user agent.