### PR TITLE
Add #samsung_browser? to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ browser.phantom_js?
 browser.quicktime?
 browser.safari?
 browser.safari_webapp_mode?
+browser.samsung_browser?
 browser.to_s            # the meta info joined by space
 browser.uc_browser?
 browser.version         # major version number


### PR DESCRIPTION
Back in #449, Browser gem introduced support for Samsung Browser. However, it seems like this method has never been added to the README.md.

This PR adds `#samsung_browser?` to the list of available methods in the README.md.