### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/browser.gemspec
+++ b/browser.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.authors               = ["Nando Vieira"]
   s.email                 = ["fnando.vieira@gmail.com"]
-  s.homepage              = "http://github.com/fnando/browser"
+  s.homepage              = "https://github.com/fnando/browser"
   s.summary               = "Do some browser detection with Ruby."
   s.description           = s.summary
   s.license               = "MIT"


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/browser or some tools or APIs that use the gem's metadata.