### PR TITLE
Add Funnelback to bots.yml

### DIFF
--- a/bots.yml
+++ b/bots.yml
@@ -79,6 +79,7 @@ feedfetcher-google: Google Feedfetcher
 findxbot: Findxbot
 flipboardproxy: FlipboardProxy
 friendfeedbot: FriendFeed
+funnelback: Funnelback
 fyrebot: Fyrebot
 garlik: GarlikCrawler
 genieo: Genieo Web filter bot


### PR DESCRIPTION
Would appreciate adding support by default to identify Funnelback crawlers!

Funnelback is an enterprise search engine platform.

See https://docs.funnelback.com/15.24/administer/reference-documents/collection-options/crawler.robotAgent.html for details about this crawler.