### PR TITLE
Changed to delay parsing AcceptLanguage until `Browser::Base#accept_language called first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Changed to delay parsing AcceptLanguage until `Browser::Base#accept_language called first.
+
 ## 5.0.0
 
 - Rename `Browser::Platform#other?` to `Browser::Platform#unknown?`.

--- a/lib/browser/base.rb
+++ b/lib/browser/base.rb
@@ -6,20 +6,24 @@ module Browser
 
     attr_reader :ua
 
-    # Return an array with all preferred languages that this browser accepts.
-    attr_reader :accept_language
-
     def initialize(ua, accept_language: nil)
       validate_size(:user_agent, ua.to_s)
-      validate_size(:accept_language, accept_language.to_s)
 
       @ua = ua
-      @accept_language = AcceptLanguage.parse(accept_language)
+      @accept_language_str = accept_language.to_s
     end
 
     # Return a meta info about this browser.
     def meta
       Meta.get(self)
+    end
+
+    # Return an array with all preferred languages that this browser accepts.
+    def accept_language
+      return @accept_language if defined? @accept_language
+
+      validate_size(:accept_language, @accept_language_str)
+      @accept_language = AcceptLanguage.parse(@accept_language_str)
     end
 
     alias_method :to_a, :meta

--- a/test/browser_test.rb
+++ b/test/browser_test.rb
@@ -169,7 +169,7 @@ class BrowserTest < Minitest::Test
               "is 257 bytes"
 
     assert_raises(Browser::Error, message) do
-      Browser.new("Chrome", accept_language: "a" * 257)
+      Browser.new("Chrome", accept_language: "a" * 257).accept_language
     end
   end
 end


### PR DESCRIPTION
I noticed that calling accept_language is rare case on our usecases, and in most cases, there is no need to parse Accept-Language.

This change is useful when parsing UserAgent of huge access logs with browser gem.

Benchmark result is followings:

```ruby
require 'benchmark/ips'
require 'browser'

target_ua = "Chrome"
target_accept_language = "en-us,en;q=0.8,pt-br;q=0.5,pt;q=0.3"

Benchmark.ips do |x|
  x.report("before") { Browser::Base.new(target_ua, accept_language: target_accept_language).accept_language }
  x.report("after") { Browser::Base.new(target_ua, accept_language: target_accept_language) }
end
```

```
$ bundle exec ruby benchamrk.rb
Warming up --------------------------------------
              before     4.274k i/100ms
               after   105.215k i/100ms
Calculating -------------------------------------
              before     42.894k (± 3.3%) i/s -    217.974k in   5.087531s
               after      1.034M (± 2.1%) i/s -      5.261M in   5.090505s
```

