### PR TITLE
Avoid exceptions due to many clients sending larger accept_language headers

### DIFF
--- a/lib/browser/browser.rb
+++ b/lib/browser/browser.rb
@@ -63,7 +63,7 @@ module Browser
   end
 
   self.user_agent_size_limit = 512
-  self.accept_language_size_limit = 256
+  self.accept_language_size_limit = 1024
 
   # Hold the list of browser matchers.
   # Order is important.


### PR DESCRIPTION
After upgrading the gem to the latest version (5.0.0), we started seeing a bunch of exceptions like this:

```
ActionView::Template::Error: accept_language cannot be larger than 256 bytes; actual size is 636
```

I know there is the option to override this preference in an initializer (for instance, `Browser.accept_language_size_limit = 1000`), which we did, but I think the gem should have a default that doesn't cause exceptions for the majority of the use cases, specially due to the nature of this verification (prevent a page from rendering because of a larger than expected accept_language header is a big deal IMHO).

The good news is that all our exceptions had the exact same header size, which was 636. However, my pull commit errs on the safe size and sets it to 1024, specially because I couldn't find any spec limiting the size of this header:

![image](https://user-images.githubusercontent.com/743879/94963902-317dc700-04cf-11eb-867c-fb3291001cd8.png)
