### PR TITLE
update changelog_uri in gemspec

### DIFF
--- a/browser.gemspec
+++ b/browser.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description           = s.summary
   s.license               = "MIT"
 
-  s.metadata["changelog_uri"] = "https://github.com/fnando/browser/blob/master/CHANGELOG.md"
+  s.metadata["changelog_uri"] = "https://github.com/fnando/browser/blob/main/CHANGELOG.md"
   
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
With the branch name change from master -> main, the changelog URI was pointing to an older version that didn't show the latest version's changes.

I found this when clicking on the changelog link on rubygems.