### PR TITLE
Add browser.device.desktop?

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ browser.device.switch?
 browser.device.xbox?
 browser.device.xbox_360?
 browser.device.xbox_one?
+browser.device.desktop?
 
 # Get platform info
 browser.platform

--- a/lib/browser/device.rb
+++ b/lib/browser/device.rb
@@ -85,6 +85,10 @@ module Browser
       detect_mobile? && !tablet?
     end
 
+    def desktop?
+      !detect_mobile? && !tablet?
+    end
+
     def ipad?
       id == :ipad
     end

--- a/test/unit/device_test.rb
+++ b/test/unit/device_test.rb
@@ -218,6 +218,7 @@ class DeviceTest < Minitest::Test
       device = Browser::Device.new(Browser[key])
       assert device.mobile?
       refute device.tablet?
+      refute device.desktop?
     end
   end
 
@@ -236,6 +237,7 @@ class DeviceTest < Minitest::Test
       device = Browser::Device.new(Browser[key])
       assert device.tablet?
       refute device.mobile?
+      refute device.desktop?
     end
   end
 


### PR DESCRIPTION
I'd like to check if the device is desktop (the device is neither mobile nor tablet).
This PR adds `browser.device.desktop?` method.