### PR TITLE
Add PetalBot to bot list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.3.2
+- Add PetalBot to bot list.
+
 ## 5.3.1
 
 - Remove Stripe webhooks from bot list.

--- a/bots.yml
+++ b/bots.yml
@@ -174,6 +174,7 @@ paperlibot: PaperLi
 peerindex: peerindex
 percolatecrawler: PercolateCrawler
 perfectmarketkwtbot: PerfectMarket
+petalbot: PetalBot
 phantomjs: PhantomJS
 pingdom: Pingdom monitoring
 pinterest: Pinterest

--- a/test/ua_bots.yml
+++ b/test/ua_bots.yml
@@ -61,6 +61,7 @@ MSNBOT_MEDIA: "msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)"
 NETCRAFT2: Netcraft SSL Server Survey - contact info@netcraft.com
 NETCRAFT: Mozilla/5.0 (compatible; NetcraftSurveyAgent/1.0; +info@netcraft.com)
 NEWRELICPINGER: NewRelicPinger/1.0 (12345)
+PETALBOT: Mozilla/5.0 (compatible;PetalBot; +https://aspiegel.com/petalbot)
 PAESSLER: Mozilla/5.0 (compatible; PRTG Network Monitor (www.paessler.com); Windows)
 PR-CY_RU: Mozilla/5.0 (compatible; PR-CY.RU; + https://a.pr-cy.ru)
 PRIVACYAWAREBOT: "Mozilla/5.0 (compatible; PrivacyAwareBot/1.1; +http://www.privacyaware.org)"


### PR DESCRIPTION
PetalBot (ex AspiegelBot) seems to a bit aggressive 😬 
More details at https://www.aspiegel.com/en/petalbot

Don't know if I has to consider a new released version in the Changelog or should have mentioned `unreleased`. Let me know if you'd prefer I update the diff 🙏 