### PR TITLE
Fix missing detection for many Kindle Fire devices

### DIFF
--- a/lib/browser/device/kindle_fire.rb
+++ b/lib/browser/device/kindle_fire.rb
@@ -12,7 +12,7 @@ module Browser
       end
 
       def match?
-        ua.match?(/Kindle Fire|KFTT/)
+        ua.match?(%r{Kindle Fire|; [^;)]+ Build/.*\bSilk/[0-9._-]+\b})
       end
     end
   end


### PR DESCRIPTION
The previous regex to detect Kindle Fire devices is incomplete, so it can only detect Kindle Fire (1st Gen) and Kindle Fire HD 7 (2nd Gen). The reason why is that it uses a device specific identifier, which is referenced as Build Model in the document.

We can fix this problem by using the more generalized regex to detect many other Kindle Fire devices. The regex is from the official document, but with a little tweaking for simplification. The original regex is for not only detecting the devices but also extracting Build Models and version number of the browser, which we do not need to do them.

https://docs.aws.amazon.com/silk/latest/developerguide/detecting-silk-ua.html

Thank you for this great gem.

Best Regards.