### PR TITLE
Add AppSignal and Checkly bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Add more bots (mostly related to AI crawlers)
+- Add AppSignal bot
+- Add Checkly bot
 
 ## 6.0.0
 

--- a/bots.yml
+++ b/bots.yml
@@ -16,6 +16,7 @@ apachebench: ApacheBench (ab)
 apis-google: APIs-Google
 appengine-google: Google App Engine
 applebot: Apple Bot
+appsignal: AppSignal Bot
 archive.org_bot: Internet Archive (archive.org)
 archiveteam archivebot: ArchiveTeam ArchiveBot
 ask jeeves: Ask Jeeves
@@ -38,6 +39,7 @@ buzzbot: Buzzbot
 buzztalk: buzztalk
 catchbot: CatchBot (catchbot.com)
 check_http: Nagios monitor
+checkly: Checkly
 chrome-lighthouse: Chrome-Lighthouse
 cipacrawler: CipaCrawler
 cliqzbot: Cliqzbot

--- a/test/ua_bots.yml
+++ b/test/ua_bots.yml
@@ -7,6 +7,7 @@ ANTHROPIC_AI: anthropic-ai
 APIS_GOOGLE: "APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)"
 APPLE_BOT: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1)"
 APPLEBOT: Applebot
+APPSIGNALBOT: "AppSignalBot/1.0 (+https://appsignal.com)"
 ARCHIVEBOT: "ArchiveTeam ArchiveBot/20190617.01 (wpull 2.0.3) and not Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.90 Safari/537.36"
 ASK: "Mozilla/2.0 (compatible; Ask Jeeves/Teoma; +http://sp.ask.com/docs/about/tech_crawling.html)"
 AWS_ELB: ELB-HealthChecker/1.0
@@ -19,6 +20,7 @@ BUZZBOT: "Buzzbot/1.0 (Buzzbot; http://www.buzzstream.com; buzzbot@buzzstream.co
 BYTESPIDER: Bytespider
 CCBOT: CCBot
 CHATGPT_USER: ChatGPT-User
+CHECKLY: "Checkly/1.0 (https://www.checklyhq.com)"
 CHROME_LIGHTHOUSE: "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3694.0 Mobile Safari/537.36 Chrome-Lighthouse"
 CIPACRAWLER: "CipaCrawler/3.0 (info@domaincrawler.com; http://www.domaincrawler.com/www.example.com)"
 CLAUDE_WEB: Claude-Web


### PR DESCRIPTION
Adds [AppSignal](https://docs.appsignal.com/uptime-monitoring/setup.html#user-agent) and [Checkly](https://www.checklyhq.com/docs/monitoring/allowlisting/#default-checkly-user-agent) bot monitors to known bots list