### PR TITLE
Update CI matrix to include all non-EOL ruby/rails pairings

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -19,11 +19,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3"]
+        ruby: ["3.2", "3.3", "3.4"]
         gemfile:
-          - Gemfile
-          - gemfiles/7_1.gemfile
           - gemfiles/7_0.gemfile
+          - gemfiles/7_1.gemfile
+          - gemfiles/7_2.gemfile
+          - gemfiles/8_0.gemfile
+        exclude:
+          - ruby-version: '3.4'
+            gemfile: 'gemfiles/7_0.gemfile'
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: >

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task :rubocop do
       --display-style-guide
       --display-cop-names
       --extra-details
-      --auto-correct
+      --autocorrect
     ]
   end
 end

--- a/gemfiles/7_2.gemfile
+++ b/gemfiles/7_2.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec path: ".."
+
+gem "rails", "~> 7.2.0"

--- a/gemfiles/8_0.gemfile
+++ b/gemfiles/8_0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec path: ".."
+
+gem "rails", "~> 8.0.0"


### PR DESCRIPTION
Changes:

- Add ruby 3.4 to list
- Add explicit `gemfiles/` entries for rails 7.2 and 8.0 (side note here ... looks like these gemfiles/ are just added/maintained manually?)
- While in there, change a rubocop option (avoids deprecation output)

I've excluded the ruby-3.4/rails-7.0 combination, which has issues. Rails 7.0 is EOL in a few months, so probably fine to just tolerate this exclusion, and/or watch to see if a 7.0.x release resolves issues.